### PR TITLE
[FEAT] 페이지 구조 설계 및 레이아웃 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-query-devtools": "^5.56.2",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import '@/styles/global.css'
+import { RouterProvider } from 'react-router-dom'
+import AppRouter from './routes/AppRouter'
 
 function App() {
-  return <p className="text-2xl font-bold text-primary-base">test</p>
+  return <RouterProvider router={AppRouter} />
 }
 
 export default App

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,5 @@
+const Input = () => {
+  return <>common input</>
+}
+
+export default Input

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input'

--- a/src/components/layout/BottomBar.tsx
+++ b/src/components/layout/BottomBar.tsx
@@ -1,0 +1,5 @@
+const BottomBar = () => {
+  return <div className="flex">bottom bar</div>
+}
+
+export default BottomBar

--- a/src/components/layout/DesktopLayout.tsx
+++ b/src/components/layout/DesktopLayout.tsx
@@ -1,0 +1,17 @@
+import { LandingPage } from '@/pages'
+import React from 'react'
+
+type Props = {
+  children: React.ReactNode
+}
+
+const DesktopLayout = ({ children }: Props) => {
+  return (
+    <div className="layout">
+      <LandingPage />
+      {children}
+    </div>
+  )
+}
+
+export default DesktopLayout

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,5 @@
+const Header = () => {
+  return <header className="flex">header</header>
+}
+
+export default Header

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { BottomBar, Header } from '.'
+
+type Props = {
+  children: React.ReactNode
+}
+
+const Layout = ({ children }: Props) => {
+  return (
+    <div className="container flex flex-col">
+      <Header />
+      {children}
+      <BottomBar />
+    </div>
+  )
+}
+
+export default Layout

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,4 @@
+export { default as DesktopLayout } from './DesktopLayout'
+export { default as Layout } from './Layout'
+export { default as Header } from './Header'
+export { default as BottomBar } from './BottomBar'

--- a/src/pages/CreateSchedulePage.tsx
+++ b/src/pages/CreateSchedulePage.tsx
@@ -1,0 +1,5 @@
+const CreateSchedulePage = () => {
+  return <>create schedule</>
+}
+
+export default CreateSchedulePage

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+const HomePage = () => {
+  return <>home</>
+}
+
+export default HomePage

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,5 +1,20 @@
-const LandingPage = () => {
-  return <div className="container bg-green-50">나날모아 랜딩페이지</div>
+import { cn } from '@/utils/cn'
+
+type Props = {
+  isLanding?: boolean
+}
+
+const LandingPage = ({ isLanding = false }: Props) => {
+  return (
+    <div
+      className={cn([
+        'container bg-primary-50',
+        !isLanding && 'hidden lg:block',
+      ])}
+    >
+      나날모아 랜딩페이지
+    </div>
+  )
 }
 
 export default LandingPage

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,5 @@
+const LandingPage = () => {
+  return <div className="container bg-green-50">나날모아 랜딩페이지</div>
+}
+
+export default LandingPage

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,5 @@
+const LoginPage = () => {
+  return <>login</>
+}
+
+export default LoginPage

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -1,0 +1,5 @@
+const ScheduleDetailPage = () => {
+  return <>schedule detail</>
+}
+
+export default ScheduleDetailPage

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,5 @@
+export { default as LandingPage } from './LandingPage'
+export { default as HomePage } from './HomePage'
+export { default as LoginPage } from './LoginPage'
+export { default as CreateSchedulePage } from './CreateSchedulePage'
+export { default as ScheduleDetailPage } from './ScheduleDetailPage'

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -12,7 +12,7 @@ import { path } from './path'
 const AppRouter = createBrowserRouter([
   {
     path: '/',
-    element: <LandingPage />,
+    element: <LandingPage isLanding />,
   },
   {
     path: path.login,

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -1,0 +1,51 @@
+import { DesktopLayout, Layout } from '@/components/layout'
+import {
+  CreateSchedulePage,
+  HomePage,
+  LandingPage,
+  LoginPage,
+  ScheduleDetailPage,
+} from '@/pages'
+import { Outlet, createBrowserRouter } from 'react-router-dom'
+import { path } from './path'
+
+const AppRouter = createBrowserRouter([
+  {
+    path: '/',
+    element: <LandingPage />,
+  },
+  {
+    path: path.login,
+    element: (
+      <DesktopLayout>
+        <LoginPage />
+      </DesktopLayout>
+    ),
+  },
+  {
+    path: path.schedules,
+    element: (
+      <DesktopLayout>
+        <Layout>
+          <Outlet />
+        </Layout>
+      </DesktopLayout>
+    ),
+    children: [
+      {
+        path: '',
+        element: <HomePage />,
+      },
+      {
+        path: path.createSchedule,
+        element: <CreateSchedulePage />,
+      },
+      {
+        path: path.scheduleDetail,
+        element: <ScheduleDetailPage />,
+      },
+    ],
+  },
+])
+
+export default AppRouter

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -1,0 +1,6 @@
+export const path = {
+  login: '/login',
+  schedules: '/schedules',
+  createSchedule: 'create',
+  scheduleDetail: ':id',
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,7 @@
+export enum DateFormatTypeEnum {
+  DateWithDots = 'yyyy.MM.dd',
+  DateWithSlash = 'yyyy/MM/dd',
+  YearAndMonth = 'yyyy.MM',
+  MonthAndDay = 'MM.dd',
+  DateWithKorean = 'yyyy년 MM월 dd일',
+}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export const cn = (...inputs: ClassValue[]) => {
+  return twMerge(clsx(inputs))
+}

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -1,0 +1,12 @@
+import { format } from 'date-fns'
+
+import { DateFormatTypeEnum } from '@/types/common'
+
+export function formatDate(
+  type: DateFormatTypeEnum,
+  date?: string | Date | null
+) {
+  if (!date) return '-'
+
+  return format(new Date(date), type as string)
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import plugin from 'tailwindcss/plugin'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
@@ -35,5 +37,16 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(({ addUtilities }) =>
+      addUtilities({
+        '.layout': {
+          '@apply mx-auto max-w-lg lg:max-w-5xl lg:flex lg:gap-x-10': '',
+        },
+        '.container': {
+          '@apply max-w-lg mx-auto min-h-dvh': '',
+        },
+      })
+    ),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,6 +434,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@remix-run/router@1.19.2":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.19.2.tgz#0c896535473291cb41f152c180bedd5680a3b273"
+  integrity sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==
+
 "@rollup/rollup-android-arm-eabi@4.21.3":
   version "4.21.3"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.3.tgz#155c7d82c1b36c3ad84d9adf9b3cd520cba81a0f"
@@ -981,6 +986,11 @@ csstype@^3.0.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@~4.3.6:
   version "4.3.7"
@@ -1954,6 +1964,21 @@ react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
+
+react-router-dom@^6.26.2:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.26.2.tgz#a6e3b0cbd6bfd508e42b9342099d015a0ac59680"
+  integrity sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==
+  dependencies:
+    "@remix-run/router" "1.19.2"
+    react-router "6.26.2"
+
+react-router@6.26.2:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.26.2.tgz#2f0a68999168954431cdc29dd36cec3b6fa44a7e"
+  integrity sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==
+  dependencies:
+    "@remix-run/router" "1.19.2"
 
 react@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
## ✅ 이슈 번호
#3 

## ✅ 작업 내용
- 레포 폴더 구조를 다음과 같이 구축했습니다.
   ```text
       src
       ㄴ components // 컴포넌트
       ㄴ pages // 페이지
       ㄴ routes // 라우팅
       ㄴ styles // 스타일
       ㄴ types // 타입
       ㄴ utils // 유틸 함수
       ㄴ hooks(예정) // 커스텀 훅
       ㄴ apis(예정) // api 관련
       ㄴ constants(예정) // 상수 모음
   ```
   - 파일명 컨벤션을 정해야 합니다.
      - 개인적으로 컴포넌트 -> `PascalCase`, 그 외 모든 파일 -> `kebab-case`를 선호해서 우선 이대로 적용했습니다.
- 페이지 구조를 설계하고 라우팅을 설정했습니다.
   - 랜딩 페이지
      - 앱 첫 진입 시 로그인 여부 체크, 와이어프레임의 main frame
    - 로그인 페이지
    - 인증된 사용자만 진입 가능한 페이지들
       - 홈 페이지
       - 일정 등록 페이지
       - 일정 상세 페이지
       - 설정 페이지(예정)
- 레이아웃을 설정했습니다.
   - 데스크탑 (viewport width 1024px 이상)
       ![스크린샷 2024-09-21 오전 12 24 29](https://github.com/user-attachments/assets/8e22d1f1-1526-4c9c-b156-d2935c5e3b7e)
   - 모바일 (viewport width 1024px 미만)
      ![스크린샷 2024-09-21 오전 12 29 57](https://github.com/user-attachments/assets/bf032333-7b3a-414a-965d-8b4767f9055d)
- 기본 유틸 함수들을 추가했습니다.
   - `formatDate`
       - 날짜 객체를 원하는 포맷의 문자열으로 변환하는 함수입니다.
          ```ts
           formatDate(DateFormatTypeEnum.DateWithKorean, new Date()) // 2024년 09월 21일
          ```
   - `cn`
        - tailwind className 문자열을 동적으로 생성하고 충돌하는 클래스를 병합합니다.
        ```ts
        cn('text-lg', 'p-4', false && 'hidden', 'p-2') // 'text-lg p-2'
        ```



## ✅ 공유 사항
선호하는 파일명 컨벤션이 있으시면 공유해주세요. 없으시면 컴포넌트 -> `PascalCase`, 그 외 모든 파일 -> `kebab-case` 이대로 가겠습니다!