### PR TITLE
[FEAT] axios 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# env
+.env

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-empty-object-type': ['off'],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.56.2",
     "axios": "^1.7.7",
     "date-fns": "^4.1.0",
+    "js-cookie": "^3.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/js-cookie": "^3.0.6",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,18 @@
 import '@/styles/global.css'
 import { RouterProvider } from 'react-router-dom'
 import AppRouter from './routes/AppRouter'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
+const queryClient = new QueryClient()
 
 function App() {
-  return <RouterProvider router={AppRouter} />
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={AppRouter} />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
 }
 
 export default App

--- a/src/api/axios-instance.ts
+++ b/src/api/axios-instance.ts
@@ -1,0 +1,32 @@
+import axios, { CreateAxiosDefaults } from 'axios'
+import { checkAccessToken, handleAuthError } from './interceptors'
+
+const createAxiosInstance = (config: CreateAxiosDefaults) => {
+  const axiosInstance = axios.create(config)
+  const useAuth = config.withCredentials
+
+  if (useAuth) {
+    axiosInstance.interceptors.request.use(checkAccessToken)
+    axiosInstance.interceptors.response.use(
+      (response) => response,
+      handleAuthError
+    )
+  }
+
+  return axiosInstance
+}
+
+export const authAPI = createAxiosInstance({
+  baseURL: import.meta.env.VITE_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+export const baseAPI = createAxiosInstance({
+  baseURL: import.meta.env.VITE_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+})

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,0 +1,48 @@
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '@/constants/api'
+import { path } from '@/routes/path'
+import { AxiosError, HttpStatusCode, InternalAxiosRequestConfig } from 'axios'
+import Cookies from 'js-cookie'
+import { baseAPI } from './axios-instance'
+
+export const checkAccessToken = (config: InternalAxiosRequestConfig) => {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY)
+
+  if (!accessToken) {
+    window.location.href = path.login
+    throw new Error('토큰이 유효하지 않습니다.')
+  }
+
+  config.headers.Authorization = `Bearer ${accessToken}`
+
+  return config
+}
+
+export const handleAuthError = async (error: AxiosError) => {
+  if (
+    !error.response ||
+    !error.config ||
+    error.response.status !== HttpStatusCode.Unauthorized
+  )
+    return Promise.reject(error)
+
+  const originalRequest = error.config
+
+  if (error.response.status === HttpStatusCode.Unauthorized) {
+    const cookie = Cookies.get(REFRESH_TOKEN_KEY)
+
+    if (!cookie) {
+      window.location.href = path.login
+      return Promise.reject(error)
+    }
+
+    try {
+      // TODO: refresh token
+      originalRequest.headers.retry = true
+      originalRequest.headers.Authorization = `Bearer`
+    } catch (error) {
+      return Promise.reject(error)
+    }
+
+    return baseAPI(originalRequest)
+  }
+}

--- a/src/api/schedules/get-schedule-by-id.ts
+++ b/src/api/schedules/get-schedule-by-id.ts
@@ -1,0 +1,12 @@
+import { GetScheduleByIdRes } from '@/types/schedules'
+import { authAPI } from '../axios-instance'
+import { API_DOMAINS } from '@/constants/api'
+
+export const getScheduleById = async (id: string) => {
+  // TODO: 중간발표 이후에 baseAPI로 변경
+  const { data } = await authAPI.get<GetScheduleByIdRes>(
+    `${API_DOMAINS.SCHEDULES}/${id}`
+  )
+
+  return data
+}

--- a/src/api/schedules/get-schedules.ts
+++ b/src/api/schedules/get-schedules.ts
@@ -1,0 +1,12 @@
+import { API_DOMAINS } from '@/constants/api'
+import { authAPI } from '../axios-instance'
+import { GetSchedulesRes } from '@/types/schedules'
+
+export const getSchedules = async (userId: number) => {
+  // TODO: 중간발표 이후에 baseAPI로 변경
+  const { data } = await authAPI.get<GetSchedulesRes>(API_DOMAINS.SCHEDULES, {
+    params: { userId },
+  })
+
+  return data
+}

--- a/src/api/schedules/post-schedules.ts
+++ b/src/api/schedules/post-schedules.ts
@@ -1,0 +1,14 @@
+import { API_DOMAINS } from '@/constants/api'
+import { authAPI } from '../axios-instance'
+import { PostSchedulesReq, PostSchedulesRes } from '@/types/schedules'
+import { AxiosResponse } from 'axios'
+
+export const postSchedules = async (payload: PostSchedulesReq) => {
+  // TODO: 중간발표 이후에 baseAPI로 변경
+  const { data } = await authAPI.post<
+    PostSchedulesReq,
+    AxiosResponse<PostSchedulesRes>
+  >(API_DOMAINS.SCHEDULES, payload)
+
+  return data
+}

--- a/src/api/schedules/post-upload-audio-file.ts
+++ b/src/api/schedules/post-upload-audio-file.ts
@@ -1,0 +1,21 @@
+import { API_DOMAINS } from '@/constants/api'
+import {
+  PostUploadAudioFileReq,
+  PostUploadAudioFileRes,
+} from '@/types/schedules'
+import { AxiosResponse } from 'axios'
+import { authAPI } from '../axios-instance'
+
+export const postUploadAudioFile = async (payload: PostUploadAudioFileReq) => {
+  // TODO: 중간발표 이후에 baseAPI로 변경
+  const { data } = await authAPI.post<
+    PostUploadAudioFileReq,
+    AxiosResponse<PostUploadAudioFileRes>
+  >(`${API_DOMAINS.SCHEDULES}/upload`, payload, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
+
+  return data
+}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,7 +6,7 @@ export const API_DOMAINS = {
   AUTH: '/auth',
   USERS: '/users',
   SCHEDULES: '/schedules',
-  GROUP: 'group',
+  GROUP: '/group',
 }
 
 export const QUERY_KEYS = {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,15 @@
+export const ACCESS_TOKEN_KEY = 'accessToken'
+
+export const REFRESH_TOKEN_KEY = 'refreshToken'
+
+export const API_DOMAINS = {
+  AUTH: '/auth',
+  USERS: '/users',
+  SCHEDULES: '/schedules',
+  GROUP: 'group',
+}
+
+export const QUERY_KEYS = {
+  GET_SCHEDULES: 'schedules',
+  GET_SCHEDULE_BY_ID: 'scheduleById',
+}

--- a/src/types/schedules.ts
+++ b/src/types/schedules.ts
@@ -20,13 +20,8 @@ export interface PostUploadAudioFileReq {
   currentDateTime: Date
 }
 
-export interface PostUploadAudioFileRes extends Array<ISchedule> {}
+export interface PostUploadAudioFileRes extends ISchedule {}
 
-export interface PostConfirmScheduleReq {}
-
-export interface PostConfirmScheduleRes {}
-
-// TODO: 중간발표 이후
 export interface PostSchedulesReq {
   categoryId: number
   startDate: Date

--- a/src/types/schedules.ts
+++ b/src/types/schedules.ts
@@ -1,0 +1,40 @@
+export interface ISchedule {
+  userId: number
+  categoryId: number
+  startDate: Date
+  endDate: Date
+  title: string
+  place: string
+  memo?: string
+  isGroupSchedule: boolean
+  isAllDay: boolean
+  scheduleId: number
+}
+
+export interface GetScheduleByIdRes extends ISchedule {}
+
+export interface GetSchedulesRes extends Array<ISchedule> {}
+
+export interface PostUploadAudioFileReq {
+  audio: string
+  currentDateTime: Date
+}
+
+export interface PostUploadAudioFileRes extends Array<ISchedule> {}
+
+export interface PostConfirmScheduleReq {}
+
+export interface PostConfirmScheduleRes {}
+
+// TODO: 중간발표 이후
+export interface PostSchedulesReq {
+  categoryId: number
+  startDate: Date
+  endDate: Date
+  title: string
+  place: string
+  memo: string
+  isGroupSchedule: boolean
+}
+
+export interface PostSchedulesRes {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,6 +581,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/prop-types@*":
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
@@ -1511,6 +1516,11 @@ jiti@^1.21.0:
   version "1.21.6"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
+
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## ✅ 이슈 번호
#16 

## ✅ 작업 내용
- axios 세팅
   - 인스턴스 생성
      - 헤더에 토큰 필요 -> `baseAPI`
      - 헤더에 토큰 필요X -> `authAPI`
   - baseAPI에 request, response interceptors 추가
- api domain별로 함수 추가
- `react-query` 세팅 

## ✅ 공유 사항

중간발표 때는 인증이 모두 빠지기 때문에 토큰이 필요없는 `authAPI`로 호출하시면 됩니다.
