### PR TITLE
[FEAT] 일정 화면 UI 구현

### DIFF
--- a/src/components/audio/StartAudio.tsx
+++ b/src/components/audio/StartAudio.tsx
@@ -44,7 +44,7 @@ const StartAudio = () => {
             direction="horizontal"
             icon={<PrevIcon />}
             text="이전"
-            className="mx-auto flex h-full items-center justify-center text-white"
+            className="mx-auto flex h-full items-center justify-center"
           />
         </Link>
         <div className="flex items-center text-red-500">

--- a/src/components/common/CategoryTag.tsx
+++ b/src/components/common/CategoryTag.tsx
@@ -1,22 +1,29 @@
 import { Categories, CategoryEnum } from '@/types/category'
 import { cn } from '@/utils/cn'
 
-// backend에서 들어오는 정보 형태에 따라 수정
-
 type Props = {
   label: Categories
-}
+  className?: string
+  as?: 'span' | 'button'
+} & React.HTMLAttributes<HTMLElement>
 
-const CategoryTag = ({ label }: Props) => {
+const CategoryTag = ({
+  label,
+  className,
+  as: Component = 'span',
+  ...props
+}: Props) => {
   return (
-    <span
+    <Component
       className={cn(
         CategoryEnum[label],
-        'mr-1 rounded-lg px-2 py-1 text-xs text-white'
+        'mr-1 rounded-lg px-2 py-1 text-xs text-white',
+        className
       )}
+      {...props}
     >
       {label}
-    </span>
+    </Component>
   )
 }
 

--- a/src/components/common/CategoryTag.tsx
+++ b/src/components/common/CategoryTag.tsx
@@ -1,0 +1,17 @@
+import { Categories, CategoryEnum } from '@/types/category.model'
+
+type Props = {
+  label: Categories
+}
+
+const CategoryTag = ({ label }: Props) => {
+  return (
+    <span
+      className={`${CategoryEnum[label]} mr-1 rounded-lg px-2 py-1 text-xs text-white`}
+    >
+      {label}
+    </span>
+  )
+}
+
+export default CategoryTag

--- a/src/components/common/CategoryTag.tsx
+++ b/src/components/common/CategoryTag.tsx
@@ -1,4 +1,7 @@
-import { Categories, CategoryEnum } from '@/types/category.model'
+import { Categories, CategoryEnum } from '@/types/category'
+import { cn } from '@/utils/cn'
+
+// backend에서 들어오는 정보 형태에 따라 수정
 
 type Props = {
   label: Categories
@@ -7,7 +10,10 @@ type Props = {
 const CategoryTag = ({ label }: Props) => {
   return (
     <span
-      className={`${CategoryEnum[label]} mr-1 rounded-lg px-2 py-1 text-xs text-white`}
+      className={cn(
+        CategoryEnum[label],
+        'mr-1 rounded-lg px-2 py-1 text-xs text-white'
+      )}
     >
       {label}
     </span>

--- a/src/components/icons/PrevIcon.tsx
+++ b/src/components/icons/PrevIcon.tsx
@@ -1,10 +1,6 @@
 import { cn } from '@/utils/cn'
 
-const PrevIcon = ({
-  className,
-  color = '#ffffff',
-  ...props
-}: React.ComponentProps<'svg'>) => {
+const PrevIcon = ({ className, ...props }: React.ComponentProps<'svg'>) => {
   return (
     <svg
       width="54px"
@@ -25,7 +21,7 @@ const PrevIcon = ({
       <g id="SVGRepo_iconCarrier">
         <path
           d="M364.8 106.666667L298.666667 172.8 637.866667 512 298.666667 851.2l66.133333 66.133333L768 512z"
-          fill={color}
+          className="fill-current"
         ></path>
       </g>
     </svg>

--- a/src/components/icons/PrevIcon.tsx
+++ b/src/components/icons/PrevIcon.tsx
@@ -1,6 +1,10 @@
 import { cn } from '@/utils/cn'
 
-const PrevIcon = ({ className, ...props }: React.ComponentProps<'svg'>) => {
+const PrevIcon = ({
+  className,
+  color = '#ffffff',
+  ...props
+}: React.ComponentProps<'svg'>) => {
   return (
     <svg
       width="54px"
@@ -21,7 +25,7 @@ const PrevIcon = ({ className, ...props }: React.ComponentProps<'svg'>) => {
       <g id="SVGRepo_iconCarrier">
         <path
           d="M364.8 106.666667L298.666667 172.8 637.866667 512 298.666667 851.2l66.133333 66.133333L768 512z"
-          fill="#ffffff"
+          fill={color}
         ></path>
       </g>
     </svg>

--- a/src/components/schedule/CalendarView.tsx
+++ b/src/components/schedule/CalendarView.tsx
@@ -1,0 +1,5 @@
+const CalendarView = () => {
+  return <div>CalendarView</div>
+}
+
+export default CalendarView

--- a/src/components/schedule/EventContainer.tsx
+++ b/src/components/schedule/EventContainer.tsx
@@ -1,0 +1,11 @@
+import EventItem from './EventItem'
+
+const EventContainer = () => {
+  return (
+    <>
+      <EventItem />
+    </>
+  )
+}
+
+export default EventContainer

--- a/src/components/schedule/EventContainer.tsx
+++ b/src/components/schedule/EventContainer.tsx
@@ -4,6 +4,7 @@ const EventContainer = () => {
   return (
     <>
       <EventItem />
+      <EventItem />
     </>
   )
 }

--- a/src/components/schedule/EventItem.tsx
+++ b/src/components/schedule/EventItem.tsx
@@ -1,9 +1,11 @@
+import { Link } from 'react-router-dom'
 import CategoryTag from '../common/CategoryTag'
+import { path } from '@/routes/path'
 
 const EventItem = () => {
   return (
-    <div
-      onClick={() => {}}
+    <Link
+      to={`${path.schedules}/1`}
       className={`mx-6 mb-4 flex cursor-pointer items-start rounded-lg border px-1 py-2 shadow-sm transition duration-300 ease-in-out hover:scale-[1.02] hover:shadow-md`}
     >
       <span className="px-3 py-2 text-lg font-semibold">15:00</span>
@@ -19,7 +21,7 @@ const EventItem = () => {
           </span>
         </div>
       </span>
-    </div>
+    </Link>
   )
 }
 

--- a/src/components/schedule/EventItem.tsx
+++ b/src/components/schedule/EventItem.tsx
@@ -1,0 +1,5 @@
+const EventItem = () => {
+  return <div>EventItem</div>
+}
+
+export default EventItem

--- a/src/components/schedule/EventItem.tsx
+++ b/src/components/schedule/EventItem.tsx
@@ -6,7 +6,7 @@ const EventItem = () => {
       onClick={() => {}}
       className={`mx-6 mb-4 flex cursor-pointer items-start rounded-lg border px-1 py-2 shadow-sm transition duration-300 ease-in-out hover:scale-[1.02] hover:shadow-md`}
     >
-      <span className="px-3 py-2 text-xl font-medium">15:00</span>
+      <span className="px-3 py-2 text-lg font-semibold">15:00</span>
 
       <span className="w-full border-l px-4 py-2">
         <div className="mb-1">

--- a/src/components/schedule/EventItem.tsx
+++ b/src/components/schedule/EventItem.tsx
@@ -1,5 +1,26 @@
+import CategoryTag from '../common/CategoryTag'
+
 const EventItem = () => {
-  return <div>EventItem</div>
+  return (
+    <div
+      onClick={() => {}}
+      className={`mx-6 mb-4 flex cursor-pointer items-start rounded-lg border px-1 py-2 shadow-sm transition duration-300 ease-in-out hover:scale-[1.02] hover:shadow-md`}
+    >
+      <span className="px-3 py-2 text-xl font-medium">15:00</span>
+
+      <span className="w-full border-l px-4 py-2">
+        <div className="mb-1">
+          <CategoryTag label="병원" />
+          <span className="p-1 text-base">정형외과 물리치료</span>
+        </div>
+        <div className="flex justify-end">
+          <span className="rounded-lg bg-gray-200 px-2 py-1 text-xs">
+            요양사 최요양
+          </span>
+        </div>
+      </span>
+    </div>
+  )
 }
 
 export default EventItem

--- a/src/components/schedule/Tabs.tsx
+++ b/src/components/schedule/Tabs.tsx
@@ -1,0 +1,40 @@
+interface TabsProps<T extends string> {
+  activeTab: T
+  setActiveTab: (tab: T) => void
+  tabs: T[]
+}
+
+const Tabs = <T extends string>({
+  activeTab,
+  setActiveTab,
+  tabs,
+}: TabsProps<T>) => {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="rounded-lg bg-white p-1 shadow-md">
+        <div className="relative flex">
+          {tabs.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`relative z-10 px-4 py-2 text-sm font-medium transition-colors duration-300 ${
+                activeTab === tab
+                  ? 'text-white'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+          <div
+            className={`absolute left-0 top-0 h-full w-1/2 rounded bg-primary-500 transition-transform duration-300 ease-in-out ${
+              activeTab === '월간' ? 'translate-x-full transform' : ''
+            }`}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Tabs

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,9 +19,9 @@ const HomePage = () => {
         />
       </div>
 
-      <EventContainer />
+      {activeTab === '일간' && <EventContainer />}
 
-      <CalendarView />
+      {activeTab === '월간' && <CalendarView />}
     </>
   )
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,29 @@
+import CalendarView from '@/components/schedule/CalendarView'
+import EventContainer from '@/components/schedule/EventContainer'
+import Tabs from '@/components/schedule/Tabs'
+import { useState } from 'react'
+
+type Schedule = '일간' | '월간'
+
 const HomePage = () => {
-  return <>home</>
+  const [activeTab, setActiveTab] = useState<Schedule>('일간')
+  const tabs: Schedule[] = ['일간', '월간']
+
+  return (
+    <>
+      <div className="py-5">
+        <Tabs<Schedule>
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          tabs={tabs}
+        />
+      </div>
+
+      <EventContainer />
+
+      <CalendarView />
+    </>
+  )
 }
 
 export default HomePage

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -1,14 +1,27 @@
+import CategoryTag from '@/components/common/CategoryTag'
 import PrevIcon from '@/components/icons/PrevIcon'
 import { path } from '@/routes/path'
 import { Link } from 'react-router-dom'
 
+type InfoItemProps = {
+  label: string
+  content: string
+}
+
+const InfoItem = ({ label, content }: InfoItemProps) => (
+  <div className="mb-5 flex items-center" aria-label={`${label}: ${content}`}>
+    <div className="mr-4 w-24 text-left font-bold">{label}</div>
+    <div>{content}</div>
+  </div>
+)
+
 const ScheduleDetailPage = () => {
   return (
-    <>
-      <div className="flex justify-between px-3 py-2">
+    <div className="px-5">
+      <div className="flex justify-between py-2">
         <Link
           to={path.schedules}
-          className="w-25 flex rounded border-gray-700 px-3 py-2"
+          className="w-25 flex rounded border-gray-700 py-2"
         >
           <PrevIcon color="#000000" className="mt-1 h-5" />
           <div className="text-base text-gray-600 hover:text-gray-900">
@@ -26,7 +39,16 @@ const ScheduleDetailPage = () => {
           </button>
         </div>
       </div>
-    </>
+
+      <div className="px-7 py-5">
+        <InfoItem label="제목" content="정형외과 물리치료" />
+        <div className="mb-5 flex items-center">
+          <div className="mr-4 w-24 text-left font-bold">카테고리</div>
+          <CategoryTag label="병원" />
+        </div>
+        <InfoItem label="날짜 및 시간" content="2024년 9월 21일 오후 3시" />
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -9,7 +9,10 @@ type InfoItemProps = {
 }
 
 const InfoItem = ({ label, content }: InfoItemProps) => (
-  <div className="mb-5 flex items-center" aria-label={`${label}: ${content}`}>
+  <div
+    className="mb-5 flex flex-col sm:flex-row sm:items-center"
+    aria-label={`${label}: ${content}`}
+  >
     <div className="mr-4 w-24 text-left font-bold">{label}</div>
     <div>{content}</div>
   </div>
@@ -23,7 +26,7 @@ const ScheduleDetailPage = () => {
           to={path.schedules}
           className="w-25 flex rounded border-gray-700 py-2"
         >
-          <PrevIcon color="#000000" className="mt-1 h-5" />
+          <PrevIcon className="mt-1 h-5" />
           <div className="text-base text-gray-600 hover:text-gray-900">
             돌아가기
           </div>
@@ -42,9 +45,11 @@ const ScheduleDetailPage = () => {
 
       <div className="px-7 py-5">
         <InfoItem label="제목" content="정형외과 물리치료" />
-        <div className="mb-5 flex items-center">
+        <div className="mb-5 flex flex-col sm:flex-row sm:items-center">
           <div className="mr-4 w-24 text-left font-bold">카테고리</div>
-          <CategoryTag label="병원" />
+          <div>
+            <CategoryTag label="병원" />
+          </div>
         </div>
         <InfoItem label="날짜 및 시간" content="2024년 9월 21일 오후 3시" />
       </div>

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -1,5 +1,26 @@
+import PrevIcon from '@/components/icons/PrevIcon'
+
 const ScheduleDetailPage = () => {
-  return <>schedule detail</>
+  return (
+    <>
+      <div>
+        <button>
+          <PrevIcon color="#000000" />
+          <span>돌아가기</span>
+        </button>
+
+        <div>
+          <button>
+            <div>수정</div>
+          </button>
+
+          <button>
+            <div>삭제</div>
+          </button>
+        </div>
+      </div>
+    </>
+  )
 }
 
 export default ScheduleDetailPage

--- a/src/pages/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage.tsx
@@ -1,15 +1,22 @@
 import PrevIcon from '@/components/icons/PrevIcon'
+import { path } from '@/routes/path'
+import { Link } from 'react-router-dom'
 
 const ScheduleDetailPage = () => {
   return (
     <>
-      <div>
-        <button>
-          <PrevIcon color="#000000" />
-          <span>돌아가기</span>
-        </button>
+      <div className="flex justify-between px-3 py-2">
+        <Link
+          to={path.schedules}
+          className="w-25 flex rounded border-gray-700 px-3 py-2"
+        >
+          <PrevIcon color="#000000" className="mt-1 h-5" />
+          <div className="text-base text-gray-600 hover:text-gray-900">
+            돌아가기
+          </div>
+        </Link>
 
-        <div>
+        <div className="flex p-2 text-base">
           <button>
             <div>수정</div>
           </button>

--- a/src/types/category.model.ts
+++ b/src/types/category.model.ts
@@ -1,0 +1,13 @@
+// backend에서 들어오는 정보 형태에 따라 수정
+
+export enum CategoryEnum {
+  가족 = 'bg-red-400',
+  병원 = 'bg-blue-500',
+  복약 = 'bg-sky-500',
+  운동 = 'bg-teal-600',
+  경조사 = 'bg-pink-400',
+  약속 = 'bg-violet-500',
+  기타 = 'bg-stone-400',
+}
+
+export type Categories = keyof typeof CategoryEnum

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,5 +1,3 @@
-// backend에서 들어오는 정보 형태에 따라 수정
-
 export enum CategoryEnum {
   가족 = 'bg-red-400',
   병원 = 'bg-blue-500',


### PR DESCRIPTION
## ✅ 이슈 번호
#14 

## ✅ 작업 내용
- HomePage.tsx 화면 구현
  - 일간, 월간 이동할 Tabs 컴포넌트 구현
  - 일간 페이지 일정 리스트 구현
- 일정 상세 페이지 ScheduleDetailPage.tsx UI 구현

## ✅ 공유 사항
- PrevIcon path의 className을 'fill-current'로 변경했습니다.
- common 폴더에 CategoryTag 컴포넌트를 구현했습니다. Prop으로`label="카테고리 이름"`을 보내면 자동으로 색상이 맵핑됩니다.