### PR TITLE
[FEAT] 일정 등록 api 연동

### DIFF
--- a/src/api/schedules/post-upload-audio-file.ts
+++ b/src/api/schedules/post-upload-audio-file.ts
@@ -10,7 +10,7 @@ export const postUploadAudioFile = async (payload: PostUploadAudioFileReq) => {
   // TODO: 중간발표 이후에 baseAPI로 변경
   const { data } = await authAPI.post<
     PostUploadAudioFileReq,
-    AxiosResponse<PostUploadAudioFileRes[]>
+    AxiosResponse<PostUploadAudioFileRes>
   >(`${API_DOMAINS.SCHEDULES}/upload`, payload, {
     headers: {
       'Content-Type': 'multipart/form-data',

--- a/src/components/create-schedule/MediaAnalysisLoadingModal.tsx
+++ b/src/components/create-schedule/MediaAnalysisLoadingModal.tsx
@@ -19,7 +19,7 @@ const MediaAnalysisLoadingModal = ({
     <Modal onClose={onClose}>
       <div className="flex flex-col items-center gap-y-4 p-4">
         <LoadingSpinner className="h-12 w-12" />
-        <p className="whitespace-pre-wrap">{text}</p>
+        <p className="whitespace-pre-wrap text-center">{text}</p>
         <Divider />
         <div className="flex flex-col items-center gap-y-2">
           <p className="text-red-500">너무 오래 걸리나요?</p>

--- a/src/components/create-schedule/MediaAnalysisResultCarousel.tsx
+++ b/src/components/create-schedule/MediaAnalysisResultCarousel.tsx
@@ -1,0 +1,87 @@
+import { DateFormatTypeEnum } from '@/types/common'
+import { IMediaAnalysisResult } from '@/types/schedules'
+import { formatDate } from '@/utils/format-date'
+import { CategoryTag } from '../common'
+import { NextIcon, PrevIcon } from '../icons'
+import { cn } from '@/utils/cn'
+
+type Props = {
+  results: Array<IMediaAnalysisResult>
+  selectedResult: IMediaAnalysisResult
+  handleSelectedResultChange: (result: IMediaAnalysisResult) => void
+}
+
+const MediaAnaysisResultCarousel = ({
+  results,
+  selectedResult,
+  handleSelectedResultChange,
+}: Props) => {
+  const currentIndex = results.indexOf(selectedResult)
+
+  return (
+    <div className="relative flex w-full gap-x-4">
+      <button
+        onClick={() =>
+          handleSelectedResultChange(
+            results[(results.length - 1 - currentIndex) % results.length]
+          )
+        }
+      >
+        <PrevIcon />
+      </button>
+      <div className="flex w-full flex-col items-center justify-center gap-y-3">
+        <div className="flex items-center">
+          {results.map((result, index) => (
+            <div
+              key={`${index}-${result.title}`}
+              className={cn(
+                'hidden',
+                index === currentIndex &&
+                  'flex h-32 w-full flex-col items-center justify-center rounded-md border-2 border-neutral-400 p-6'
+              )}
+              data-carousel-item
+            >
+              <p>
+                {formatDate(
+                  DateFormatTypeEnum.DateWithKorean,
+                  result.startDate
+                )}
+              </p>
+              <div className="flex items-center gap-x-1">
+                <CategoryTag label={'약속'} />
+                <p>{result.title}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Slider indicators */}
+        <div className="flex space-x-3 rtl:space-x-reverse">
+          {Array.from({ length: results.length }, () => true).map(
+            (_, index) => (
+              <button
+                key={index}
+                type="button"
+                className="h-2 w-2 rounded-full bg-neutral-300"
+                aria-current={currentIndex === index ? 'true' : 'false'}
+                aria-label="Slide 1"
+                data-carousel-slide-to={`${index}`}
+              />
+            )
+          )}
+        </div>
+      </div>
+      <button
+        onClick={() =>
+          handleSelectedResultChange(
+            results[(results.length - 1 - currentIndex) % results.length]
+          )
+        }
+      >
+        <NextIcon />
+      </button>
+    </div>
+  )
+}
+
+export default MediaAnaysisResultCarousel

--- a/src/components/create-schedule/audio/StartAudio.tsx
+++ b/src/components/create-schedule/audio/StartAudio.tsx
@@ -1,12 +1,11 @@
-import useAudioRecord from '@/hooks/use-audio-record'
-import { IconButton } from '../../common'
-import { InfoIcon } from '../../icons'
-import PrevIcon from '../../icons/PrevIcon'
 import MicOff from '@/assets/imgs/MicOff.svg'
 import MicOn from '@/assets/imgs/MicOn.svg'
+import useAudioRecord from '@/hooks/use-audio-record'
+import { path } from '@/routes/path'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { path } from '@/routes/path'
+import { IconButton } from '../../common'
+import { PrevIcon } from '@/components/icons'
 
 interface StartAudioProps {
   handlePost: (audioFile: File) => void
@@ -69,10 +68,11 @@ const StartAudio = ({ handlePost }: StartAudioProps) => {
             className="mx-auto flex h-full items-center justify-center"
           />
         </Link>
-        <div className="flex items-center text-red-500">
+        {/* TODO: 중간발표 보류 */}
+        {/* <div className="flex items-center text-red-500">
           <InfoIcon />
           <p>도움말</p>
-        </div>
+        </div>s */}
       </div>
       <div className="-mt-5 flex flex-col items-center justify-center border-b-8 pb-5">
         {audio ? (

--- a/src/components/create-schedule/audio/SuccessAudio.tsx
+++ b/src/components/create-schedule/audio/SuccessAudio.tsx
@@ -1,20 +1,43 @@
-import { IconButton } from '@/components/common'
 import SuccessFace from '@/assets/imgs/SuccessFace.png'
-import { HomeIcon, InfoIcon } from '@/components/icons'
-import { Link } from 'react-router-dom'
-import { path } from '@/routes/path'
+import { Button } from '@/components/common'
+import {
+  IMediaAnalysisResult,
+  PostSchedulesReq,
+  PostUploadAudioFileRes,
+} from '@/types/schedules'
+import { useState } from 'react'
+import MediaAnaysisResultCarousel from '../MediaAnalysisResultCarousel'
 
-const SuccessAudio = () => {
-  const handlePost = () => {
-    //api
+type Props = {
+  results: PostUploadAudioFileRes
+  createSchedules: (payload: PostSchedulesReq) => void
+}
+
+const SuccessAudio = ({ results, createSchedules }: Props) => {
+  const [selectedResult, setSelectedResult] = useState<IMediaAnalysisResult>(
+    results[0]
+  )
+
+  const handleSelectedResultChange = (result: IMediaAnalysisResult) => {
+    setSelectedResult(result)
+  }
+  const handleCreate = () => {
+    if (selectedResult) {
+      createSchedules({
+        ...selectedResult,
+      })
+    }
   }
 
+  console.log(selectedResult)
+
   return (
-    <div className="flex h-full flex-col p-5">
-      <div className="ml-auto flex h-10 items-center text-red-500">
+    <div className="flex h-full flex-col">
+      {/* TODO: 중간발표 보류 */}
+      {/* <div className="ml-auto flex h-10 items-center text-red-500">
         <InfoIcon />
         <p>도움말</p>
-      </div>
+      </div> */}
       <div className="mt-3 flex justify-evenly">
         <div className="flex flex-col items-center justify-center">
           <div className="mx-auto my-1 flex h-7 w-7 items-center justify-center rounded-full bg-gray-400 font-bold text-white">
@@ -44,31 +67,36 @@ const SuccessAudio = () => {
           width={240}
           height={240}
         />
-        <p className="-mt-2 mb-3 text-xl">음성 분석에 성공했습니다.</p>
-        <div className="flex h-28 w-3/4 flex-col items-center justify-center rounded-lg border-2 text-lg">
+        <p className="-mt-2 mb-6 text-xl">음성 분석에 성공했습니다.</p>
+        <MediaAnaysisResultCarousel
+          results={results}
+          selectedResult={selectedResult}
+          handleSelectedResultChange={handleSelectedResultChange}
+        />
+        {/* <div className="flex h-28 w-3/4 flex-col items-center justify-center rounded-lg border-2 text-lg">
           <p>2024년 12월 14일</p>
           <div className="flex w-full flex-row items-center justify-center">
             <p className="rounded bg-primary-blue text-white">경조사</p>
             <p>막내 결혼식</p>
           </div>
-        </div>
-        <div className="mb-10 flex w-full flex-col items-center justify-between pt-5">
+        </div> */}
+        <div className="mt-6 flex w-full flex-col items-center justify-between">
           <p>이대로 등록할까요?</p>
-          <div className="flex w-3/4">
-            <button
-              className="mx-auto h-10 w-28 rounded bg-primary-base text-lg text-white"
-              onClick={handlePost}
-            >
-              등록하기
-            </button>
-            <button className="mx-auto h-10 w-28 rounded bg-primary-base text-lg text-white">
-              수정하기
-            </button>
+          <div className="mt-4 flex items-center gap-x-6">
+            <Button
+              theme="outline"
+              text="수정하기"
+              onClick={() => {
+                alert('준비 중입니다.')
+              }}
+            />
+            <Button theme="solid" text="등록하기" onClick={handleCreate} />
           </div>
         </div>
       </div>
 
-      <Link
+      {/* TODO: 중간발표 보류 */}
+      {/* <Link
         to={path.schedules}
         className="mx-auto mb-8 mt-auto w-1/3 rounded bg-gray-300 p-2 font-semibold"
       >
@@ -78,7 +106,7 @@ const SuccessAudio = () => {
           text="처음으로"
           className="mx-auto gap-x-1"
         />
-      </Link>
+      </Link> */}
     </div>
   )
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -13,4 +13,5 @@ export const QUERY_KEYS = {
   GET_SCHEDULES: 'schedules',
   GET_SCHEDULE_BY_ID: 'scheduleById',
   POST_AUDIO_FILE: 'postAudioFile',
+  POST_SCHEDULES: 'postSchedules',
 }

--- a/src/pages/create-schedule/AudioCreatePage.tsx
+++ b/src/pages/create-schedule/AudioCreatePage.tsx
@@ -1,7 +1,6 @@
 import StartAudio from '@/components/create-schedule/audio/StartAudio'
 import FailAudio from '@/components/create-schedule/audio/FailAudio'
 import SuccessAudio from '@/components/create-schedule/audio/SuccessAudio'
-// import SuccessPostAudio from '@/components/create-schedule/audio/SuccessPostAudio'
 import { useState } from 'react'
 import MediaAnalysisLoadingModal from '@/components/create-schedule/MediaAnalysisLoadingModal'
 import { useModal } from '@/hooks/use-modal'
@@ -10,32 +9,44 @@ import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@tanstack/react-query'
 import { postUploadAudioFile } from '@/api/schedules/post-upload-audio-file'
 import {
+  PostSchedulesReq,
+  PostSchedulesRes,
   PostUploadAudioFileReq,
   PostUploadAudioFileRes,
 } from '@/types/schedules'
 import { AxiosError } from 'axios'
 import { QUERY_KEYS } from '@/constants/api'
+import { postSchedules } from '@/api/schedules/post-schedules'
+import SuccessPostAudio from '@/components/create-schedule/audio/SuccessPostAudio'
 
 const AudioCreate = () => {
   const navigate = useNavigate()
   const { closeModal } = useModal()
 
-  const [result, setResult] = useState<PostUploadAudioFileRes[]>()
+  const [results, setResults] = useState<PostUploadAudioFileRes>()
 
   const mutation = useMutation<
-    PostUploadAudioFileRes[],
+    PostUploadAudioFileRes,
     AxiosError,
     PostUploadAudioFileReq
   >({
     mutationKey: [QUERY_KEYS.POST_AUDIO_FILE],
     mutationFn: postUploadAudioFile,
     onSuccess: (res) => {
-      setResult(res)
+      setResults(res)
     },
     onError: (err) => {
       console.error('err', err)
-      setResult(undefined)
+      setResults(undefined)
     },
+  })
+  const {
+    mutate: createSchedules,
+    isSuccess: isCreateSchedulesSuccess,
+    isError: isCreateSchedulesError,
+  } = useMutation<PostSchedulesRes, AxiosError, PostSchedulesReq>({
+    mutationKey: [QUERY_KEYS.POST_SCHEDULES],
+    mutationFn: postSchedules,
   })
 
   const uploadAudio = (file: File) => {
@@ -47,10 +58,10 @@ const AudioCreate = () => {
 
   return (
     <div className="flex h-full flex-col p-5">
-      {!result && <StartAudio handlePost={uploadAudio} />}
+      {!results && <StartAudio handlePost={uploadAudio} />}
       {mutation.isPending && (
         <MediaAnalysisLoadingModal
-          text={`음성 분석 중입니다. \n잠시만 기다려주세요.`}
+          text={`음성 분석 중입니다. \n약 20~30초 정도 소요됩니다.\n 잠시만 기다려주세요.`}
           onClose={() => {
             closeModal()
             navigate(path.createSchedule.audio.about)
@@ -64,11 +75,15 @@ const AudioCreate = () => {
           }}
         />
       )}
-      {mutation.isSuccess && <SuccessAudio />}
-      {mutation.isError && <FailAudio />}
+      {mutation.isSuccess && results && !isCreateSchedulesSuccess && (
+        <SuccessAudio results={results} createSchedules={createSchedules} />
+      )}
+      {mutation.isError && !isCreateSchedulesSuccess && <FailAudio />}
 
       {/* post 등록완료 */}
-      {/* <SuccessPostAudio /> */}
+      {(isCreateSchedulesSuccess || isCreateSchedulesError) && (
+        <SuccessPostAudio />
+      )}
     </div>
   )
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,13 +4,13 @@
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('src/assets/fonts/Pretendard-Regular.woff2') format('woff2');
+  src: url('src/assets/fonts/Pretendard-Regular.woff2') format('font-woff2');
   font-weight: normal;
 }
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('src/assets/fonts/Pretendard-Bold.woff2') format('woff2');
+  src: url('src/assets/fonts/Pretendard-Bold.woff2') format('font-woff2');
   font-weight: bold;
 }
 

--- a/src/types/schedules.ts
+++ b/src/types/schedules.ts
@@ -11,6 +11,15 @@ export interface ISchedule {
   scheduleId: number
 }
 
+export interface IMediaAnalysisResult {
+  userId: number
+  startDate: Date
+  endDate: Date
+  title: string
+  place: string
+  isAllDay: boolean
+}
+
 export interface GetScheduleByIdRes extends ISchedule {}
 
 export interface GetSchedulesRes extends Array<ISchedule> {}
@@ -20,23 +29,24 @@ export interface PostUploadAudioFileReq {
   currentDateTime: Date
 }
 
-export interface PostUploadAudioFileRes {
-  userId: number
-  startDate: Date
-  endDate: Date
-  title: string
-  place: string
-  isAllDay: boolean
-}
+export interface PostUploadAudioFileRes extends Array<IMediaAnalysisResult> {}
 
 export interface PostSchedulesReq {
-  categoryId: number
+  userId: number
+  categoryId?: number
   startDate: Date
   endDate: Date
-  title: string
-  place: string
-  memo: string
-  isGroupSchedule: boolean
+  title?: string
+  place?: string
+  memo?: string
+  isGroupSchedule?: boolean
+  isAllDay?: boolean
 }
 
-export interface PostSchedulesRes {}
+export interface PostSchedulesRes extends PostSchedulesReq {
+  scheduleId: number
+  category: {
+    categoryId: number
+    categoryName: string
+  }
+}


### PR DESCRIPTION
## ✅ 이슈 번호
#25 

## ✅ 작업 내용
- 분석 결과 ui -> 여러개인 경우를 고려하여 Carousel 추가
   ![스크린샷 2024-09-27 오후 2 42 00](https://github.com/user-attachments/assets/383060aa-2d3f-4ff9-bb31-5e1bceda3232)
   ![스크린샷 2024-09-27 오후 2 41 53](https://github.com/user-attachments/assets/ab12c95b-9419-4112-b727-5a3d66a4434b)
   - 양 옆 화살표 누르면 보여지는 분석 결과가 선택된 분석 결과입니다
   - 선택된 분석 결과가 일정 등록 payload로 들어갑니다
- 일정 등록 api 연동


## ✅ 공유 사항
- 임시방편으로 만든 코드가 많아 중간발표 이후에 수정이 필요합니다
- '수정하기' 버튼 누르면 '준비 중입니다.' alert가 띄워집니다.
- 카테고리 태그가 무조건 '약속'으로 보여집니다. category 관련 로직은 처리 못했습니다