### PR TITLE
[FEAT] 유저 상태 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.56.2",
     "axios": "^1.7.7",
     "date-fns": "^4.1.0",
+    "immer": "^10.1.1",
     "js-cookie": "^3.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/api/auth/post-refresh-token.ts
+++ b/src/api/auth/post-refresh-token.ts
@@ -1,0 +1,13 @@
+import { PostRefreshTokenReq, PostRefreshTokenRes } from '@/types/auth'
+import { baseAPI } from '../axios-instance'
+import { AxiosResponse } from 'axios'
+import { API_DOMAINS } from '@/constants/api'
+
+export const postRefreshToken = async (payload: PostRefreshTokenReq) => {
+  const { data } = await baseAPI.post<
+    PostRefreshTokenReq,
+    AxiosResponse<PostRefreshTokenRes>
+  >(`${API_DOMAINS.AUTH}/refresh`, payload)
+
+  return data
+}

--- a/src/api/users/get-user-me.ts
+++ b/src/api/users/get-user-me.ts
@@ -1,0 +1,9 @@
+import { API_DOMAINS } from '@/constants/api'
+import { baseAPI } from '../axios-instance'
+import { GetUserMeRes } from '@/types/auth'
+
+export const getUserMe = async () => {
+  const { data } = await baseAPI.get<GetUserMeRes>(`${API_DOMAINS.USERS}/me`)
+
+  return data
+}

--- a/src/components/schedule/EventContainer.tsx
+++ b/src/components/schedule/EventContainer.tsx
@@ -3,14 +3,15 @@ import EventItem from './EventItem'
 import { QUERY_KEYS } from '@/constants/api'
 import { getSchedules } from '@/api/schedules/get-schedules'
 import { ISchedule } from '@/types/schedules'
+import { useUser } from '@/hooks/use-user'
 
 const EventContainer = () => {
+  const { user, isUserLoading } = useUser()
   const { isLoading, data } = useQuery<ISchedule[]>({
     queryKey: [QUERY_KEYS.GET_SCHEDULES],
-    queryFn: () => getSchedules(2),
+    queryFn: () => getSchedules(user.userId || 0),
+    enabled: !isUserLoading && !!user.userId,
   })
-
-  console.log(data)
 
   const sortScheduleDESC = (schedules: ISchedule[]) => {
     return schedules.sort(
@@ -19,7 +20,7 @@ const EventContainer = () => {
     )
   }
 
-  if (isLoading) return <div>로딩 중...</div>
+  if (isUserLoading || isLoading) return <div>로딩 중...</div>
   if (!data) return <div>데이터가 없습니다.</div>
 
   return (

--- a/src/components/schedule/EventItem.tsx
+++ b/src/components/schedule/EventItem.tsx
@@ -21,7 +21,7 @@ const EventItem = ({ schedule }: Props) => {
 
       <span className="w-full border-l px-4 py-2">
         <div className="mb-1">
-          <CategoryTag label={schedule.category.categoryName} />
+          <CategoryTag label={schedule?.category?.categoryName || '기타'} />
           <span className="p-1 text-base">{schedule.title}</span>
         </div>
         {/* <div className="flex justify-end">

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -16,6 +16,7 @@ export const API_DOMAINS = {
 export const QUERY_KEYS = {
   POST_LOGIN: 'login',
   GET_KAKAO_LOGIN: 'kakaoLogin',
+  GET_USER_ME: 'me',
   GET_SCHEDULES: 'schedules',
   GET_SCHEDULE_BY_ID: 'scheduleById',
   POST_AUDIO_FILE: 'postAudioFile',

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -1,0 +1,22 @@
+import { getUserMe } from '@/api/users/get-user-me'
+import { QUERY_KEYS } from '@/constants/api'
+import { useUserStore } from '@/store/user'
+import { GetUserMeRes } from '@/types/auth'
+import { getAccessToken } from '@/utils/handle-token'
+import { useQuery } from '@tanstack/react-query'
+
+export const useUser = () => {
+  const { data, isSuccess, isError, isLoading } = useQuery<GetUserMeRes>({
+    queryKey: [QUERY_KEYS.GET_USER_ME, getAccessToken()],
+    queryFn: getUserMe,
+  })
+  const { user, setUser } = useUserStore()
+
+  if (isSuccess) setUser(data.user.id)
+  if (isError) setUser(null)
+
+  return {
+    user,
+    isUserLoading: isLoading,
+  }
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,19 +1,19 @@
-import { cn } from '@/utils/cn'
 import landingLogo from '@/assets/logo/landingLogo.svg'
-import { ACCESS_TOKEN_KEY } from '@/constants/api'
+import { useUser } from '@/hooks/use-user'
 import { path } from '@/routes/path'
+import { cn } from '@/utils/cn'
 
 type Props = {
   isLanding?: boolean
 }
 
 const LandingPage = ({ isLanding = false }: Props) => {
-  if (isLanding) {
-    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY)
+  const { user } = useUser()
 
+  if (isLanding) {
     setTimeout(() => {
-      window.location.href = accessToken ? path.schedules : path.login
-    }, 2000)
+      window.location.href = user.isLoggedIn ? path.schedules : path.login
+    }, 1000)
   }
 
   return (

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,18 +2,13 @@ import { postLogin } from '@/api/auth/post-login'
 import kakaoLogin from '@/assets/imgs/kakaoLogin.png'
 import { Input } from '@/components/common'
 import Divider from '@/components/common/Divider'
-import {
-  ACCESS_TOKEN_KEY,
-  KAKAO_AUTH_API_URL,
-  QUERY_KEYS,
-  REFRESH_TOKEN_KEY,
-} from '@/constants/api'
+import { KAKAO_AUTH_API_URL, QUERY_KEYS } from '@/constants/api'
 import { errorMessages } from '@/constants/validation'
 import { path } from '@/routes/path'
 import { PostLoginReq, PostLoginRes } from '@/types/auth'
+import { setToken } from '@/utils/handle-token'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError, HttpStatusCode } from 'axios'
-import Cookies from 'js-cookie'
 import { useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 
@@ -29,8 +24,7 @@ const LoginPage = () => {
     mutationKey: [QUERY_KEYS.POST_LOGIN],
     mutationFn: postLogin,
     onSuccess: (data) => {
-      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
-      Cookies.set(REFRESH_TOKEN_KEY, data.refreshToken)
+      setToken(data.accessToken, data.refreshToken)
 
       setTimeout(() => {
         window.location.href = path.schedules

--- a/src/pages/LoginRedirectPage.tsx
+++ b/src/pages/LoginRedirectPage.tsx
@@ -1,16 +1,11 @@
 import { getKakaoLogin } from '@/api/auth/get-kakao-login'
 import { LoadingSpinner } from '@/components/common'
-import {
-  ACCESS_TOKEN_KEY,
-  QUERY_KEYS,
-  REFRESH_TOKEN_DURATION,
-  REFRESH_TOKEN_KEY,
-} from '@/constants/api'
+import { QUERY_KEYS } from '@/constants/api'
 import { path } from '@/routes/path'
 import { GetKaKaoLoginRes } from '@/types/auth'
+import { setToken } from '@/utils/handle-token'
 import { useQuery } from '@tanstack/react-query'
 import { AxiosError, HttpStatusCode } from 'axios'
-import Cookies from 'js-cookie'
 import { useEffect } from 'react'
 
 const LoginRedirectPage = () => {
@@ -30,11 +25,11 @@ const LoginRedirectPage = () => {
 
   useEffect(() => {
     if (!isPending && isSuccess) {
-      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
-      Cookies.set(REFRESH_TOKEN_KEY, data.refreshToken, {
-        expires: REFRESH_TOKEN_DURATION,
-      })
-      window.location.href = path.schedules
+      setToken(data.accessToken, data.refreshToken)
+
+      setTimeout(() => {
+        window.location.href = path.schedules
+      }, 1000)
     }
 
     if (!isPending && isError) {

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+
+type UserState = {
+  user: {
+    isLoggedIn: boolean
+    userId: number | null
+  }
+}
+
+type UserActions = {
+  setUser: (userId: number | null) => void
+}
+
+const initialState: UserState = {
+  user: { isLoggedIn: false, userId: null },
+}
+
+export const useUserStore = create<UserState & UserActions>()(
+  devtools(
+    immer((set) => ({
+      user: initialState.user,
+      setUser: (userId) =>
+        set((state) => {
+          if (userId) {
+            state.user = {
+              isLoggedIn: true,
+              userId,
+            }
+          } else {
+            state.user = initialState.user
+          }
+        }),
+    })),
+    { name: 'user' }
+  )
+)

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -12,6 +12,7 @@ export interface PostLoginReq {
 export interface PostLoginRes {
   accessToken: string
   refreshToken: string
+  user: IUser
 }
 
 export interface GetKaKaoLoginRes {
@@ -20,3 +21,16 @@ export interface GetKaKaoLoginRes {
   socialProvider: string
   user: IUser
 }
+
+export interface PostRefreshTokenReq {
+  userId: number
+  refreshToken: string
+  socialProvider: string
+}
+
+export interface PostRefreshTokenRes {
+  accessToken: string
+  refreshToken: string
+}
+
+export interface GetUserMeRes extends PostLoginRes {}

--- a/src/utils/handle-token.ts
+++ b/src/utils/handle-token.ts
@@ -1,0 +1,26 @@
+import {
+  ACCESS_TOKEN_KEY,
+  REFRESH_TOKEN_DURATION,
+  REFRESH_TOKEN_KEY,
+} from '@/constants/api'
+import Cookies from 'js-cookie'
+
+export const getAccessToken = () => {
+  return localStorage.getItem(ACCESS_TOKEN_KEY)
+}
+
+export const getRefreshToken = () => {
+  return Cookies.get(REFRESH_TOKEN_KEY)
+}
+
+export const setToken = (access: string, refresh: string) => {
+  localStorage.setItem(ACCESS_TOKEN_KEY, access)
+  Cookies.set(REFRESH_TOKEN_KEY, refresh, {
+    expires: REFRESH_TOKEN_DURATION,
+  })
+}
+
+export const removeToken = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  Cookies.remove(REFRESH_TOKEN_KEY)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,6 +1427,11 @@ ignore@^5.2.0, ignore@^5.3.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"


### PR DESCRIPTION
## ✅ 이슈 번호
#31 

## ✅ 작업 내용
- 토큰 재발급, 유저정보 api 연동
- access token, refresh token 관리 -> 유틸함수로 분리
- user 전역 상태 관리 로직 추가

## ✅ 공유 사항
- `useUser` 훅을 통해 userId, isLoggedIn 상태를 전역으로 관리합니다.
   ```tsx
    const { user, isUserLoading } = useUser()
   ``` 
   - loading 상태에 따른 ui 처리가 필요합니다.
- 지금 유저 정보 불러오는 api가 따로 없어 에러나는 상태입니다.
   - 연동시켜놓은 api는 백엔드 internal api 같아서 나중에 수정예정입니다.