### PR TITLE
[FIX] 랜딩페이지 리다이렉트 버그 픽스

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -6,10 +6,11 @@ import { getAccessToken } from '@/utils/handle-token'
 import { useQuery } from '@tanstack/react-query'
 import { useEffect } from 'react'
 
-export const useUser = () => {
+export const useUser = (enabled: boolean = true) => {
   const { data, isLoading } = useQuery<GetUsersMeRes>({
     queryKey: [QUERY_KEYS.GET_USER_ME, getAccessToken()],
     queryFn: getUsersMe,
+    enabled,
   })
   const { user, setUser } = useUserStore()
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const LandingPage = ({ isLanding = false }: Props) => {
-  const { user, isUserLoading } = useUser()
+  const { user, isUserLoading } = useUser(isLanding)
 
   if (isLanding && !isUserLoading) {
     setTimeout(() => {


### PR DESCRIPTION
## ✅ 이슈 번호
#38 

## ✅ 작업 내용
- 초기 상태: 브라우저 저장소에 accessToken, refreshToken 모두 존재하지 않음
- 기존 로직:
   1. 랜딩페이지 -> token을 가지고 유저 정보 조회 api call
       - baseAPI interceptor -> token이 없으면 로그인 페이지로 redirect
   2. 랜딩페이지 -> 유저 정보 조회 api call의 response 중 isLoggedIn이 false이면 로그인 페이지로 redirect
- 문제 상황: 1,2번 로직이 충돌하여 로그인 페이지로 무한 redirect
- 해결 방안: 랜딩페이지일 때만 유저 정보 조회 api call을 트리거하는 조건 추가


## ✅ 공유 사항
- 토큰을 가지고 유저 정보를 조회하는 `useUser` 훅의 인자로 `enabled`를 넘겨주면 조건부 api call이 가능합니다.