### PR TITLE
[FIX] 네이버 OAuth state 수정 및 토큰 재발급 요청 dto 수정

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -3,7 +3,6 @@ import { path } from '@/routes/path'
 import {
   getAccessToken,
   getRefreshToken,
-  getSocialProvider,
   removeToken,
   setToken,
 } from '@/utils/handle-token'
@@ -56,7 +55,6 @@ export const handleAuthError = async (error: AxiosError) => {
       const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
         await postRefreshToken({
           refreshToken,
-          socialProvider: getSocialProvider() || '',
         })
       setToken({ accessToken: newAccessToken, refreshToken: newRefreshToken })
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -2,8 +2,6 @@ export const ACCESS_TOKEN_KEY = 'accessToken'
 
 export const REFRESH_TOKEN_KEY = 'refreshToken'
 
-export const SOCIAL_PROVIDER_KEY = 'socialProvider'
-
 export const REFRESH_TOKEN_DURATION = 24
 
 export const KAKAO_AUTH_API_URL = 'https://kauth.kakao.com/oauth/authorize'

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,6 +11,7 @@ import {
 import { errorMessages } from '@/constants/validation'
 import { path } from '@/routes/path'
 import { PostLoginReq, PostLoginRes } from '@/types/auth'
+import { generateRandomState } from '@/utils/generate-random-state'
 import { setToken } from '@/utils/handle-token'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError, HttpStatusCode } from 'axios'
@@ -18,8 +19,9 @@ import { useForm } from 'react-hook-form'
 import { Link } from 'react-router-dom'
 
 const LoginPage = () => {
+  const naverRandomState = generateRandomState()
   const kakaoUrl = `${KAKAO_AUTH_API_URL}?response_type=code&client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${window.origin}${path.loginRedirect}?at=kakao`
-  const naverUrl = `${NAVER_AUTH_API_URL}?response_type=code&client_id=${import.meta.env.VITE_NAVER_CLIENT_ID}&state=${import.meta.env.VITE_NAVER_STATE}&redirect_uri=${window.origin}${path.loginRedirect}?at=naver`
+  const naverUrl = `${NAVER_AUTH_API_URL}?response_type=code&client_id=${import.meta.env.VITE_NAVER_CLIENT_ID}&state=${naverRandomState}&redirect_uri=${window.origin}${path.loginRedirect}?at=naver`
 
   const {
     register,
@@ -31,7 +33,7 @@ const LoginPage = () => {
     mutationKey: [QUERY_KEYS.POST_LOGIN],
     mutationFn: postLogin,
     onSuccess: ({ accessToken, refreshToken }) => {
-      setToken({ accessToken, refreshToken, socialProvider: '' })
+      setToken({ accessToken, refreshToken })
 
       setTimeout(() => {
         window.location.href = path.schedules

--- a/src/pages/LoginRedirectPage.tsx
+++ b/src/pages/LoginRedirectPage.tsx
@@ -40,7 +40,7 @@ const LoginRedirectPage = () => {
     accessToken,
     refreshToken,
   }: GetKaKaoLoginRes | GetNaverLoginRes) => {
-    setToken({ accessToken, refreshToken, socialProvider: at || '' })
+    setToken({ accessToken, refreshToken })
 
     setTimeout(() => {
       window.location.href = path.schedules

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -30,7 +30,6 @@ export interface GetNaverLoginRes extends GetKaKaoLoginRes {}
 
 export interface PostRefreshTokenReq {
   refreshToken: string
-  socialProvider: string
 }
 
 export interface PostRefreshTokenRes {

--- a/src/utils/generate-random-state.ts
+++ b/src/utils/generate-random-state.ts
@@ -1,0 +1,12 @@
+export const generateRandomState = () => {
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const STATE_LENGTH = 10
+  let state = ''
+
+  for (let i = 0; i < STATE_LENGTH; i++) {
+    state += characters.charAt(Math.floor(Math.random() * STATE_LENGTH))
+  }
+
+  return state
+}

--- a/src/utils/handle-token.ts
+++ b/src/utils/handle-token.ts
@@ -2,14 +2,12 @@ import {
   ACCESS_TOKEN_KEY,
   REFRESH_TOKEN_DURATION,
   REFRESH_TOKEN_KEY,
-  SOCIAL_PROVIDER_KEY,
 } from '@/constants/api'
 import Cookies from 'js-cookie'
 
 type TStorageToken = {
   accessToken: string
   refreshToken: string
-  socialProvider?: string
 }
 
 export const getAccessToken = () => {
@@ -20,17 +18,8 @@ export const getRefreshToken = () => {
   return Cookies.get(REFRESH_TOKEN_KEY)
 }
 
-export const getSocialProvider = () => {
-  return localStorage.getItem(SOCIAL_PROVIDER_KEY)
-}
-
-export const setToken = ({
-  accessToken,
-  refreshToken,
-  socialProvider,
-}: TStorageToken) => {
+export const setToken = ({ accessToken, refreshToken }: TStorageToken) => {
   localStorage.setItem(ACCESS_TOKEN_KEY, accessToken)
-  if (socialProvider) localStorage.setItem(SOCIAL_PROVIDER_KEY, socialProvider)
   Cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
     expires: REFRESH_TOKEN_DURATION,
   })


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
- 네이버 OAuth 요청에 필요한 state 값을 수정했습니다.
   - 수정 전: 환경변수에 고정값 저장
   - 수정 후: 로그인할 때마다 길이 10의 랜덤한 문자열 생성 후 전송
- 재우님과 상의 하에 토큰 재발급 api request dto를 수정했습니다.
   - 수정 전: expiredAccessToken, refreshToken
   - 수정 후: refreshToken (+header에 만료된 accessToken)

## ✅ 공유 사항
- `.env` 업데이트 사항 있습니다.
    - `VITE_NAVER_STATE` 삭제
- 현재 백엔드는 수정 전이라 로그인한 상태에서 5분 또는 15분이 지나 access token이 만료되면 토큰 재발급 api call 에러납니다.
