### PR TITLE
[FEAT] 사용자 검색 컴포넌트 추가

### DIFF
--- a/src/api/users/post-user-search.ts
+++ b/src/api/users/post-user-search.ts
@@ -1,0 +1,13 @@
+import { API_DOMAINS } from '@/constants/api'
+import { baseAPI } from '../axios-instance'
+import { PostUserSearchReq, PostUserSearchRes } from '@/types/auth'
+import { AxiosResponse } from 'axios'
+
+export const PostUsersSearch = async (payload: PostUserSearchReq) => {
+  const { data } = await baseAPI.post<
+    PostUserSearchReq,
+    AxiosResponse<PostUserSearchRes>
+  >(`${API_DOMAINS.USERS}/search`, payload)
+
+  return data
+}

--- a/src/components/common/UserSelector.tsx
+++ b/src/components/common/UserSelector.tsx
@@ -75,10 +75,16 @@ const UserSelector = ({ onClick }: Props) => {
                 className="flex cursor-pointer justify-between gap-2 py-3"
               >
                 <div className="flex gap-2">
-                  <img
-                    src={user.profileImage}
-                    className="size-8 rounded-full object-cover sm:size-9"
-                  />
+                  {!user.profileImage.length ? (
+                    <img
+                      src={user.profileImage}
+                      className="size-8 rounded-full object-cover sm:size-9"
+                    />
+                  ) : (
+                    <div className="flex size-8 items-center justify-center rounded-full border sm:size-9">
+                      {user.name[0]}
+                    </div>
+                  )}
                   <div className="flex items-center gap-1">
                     <div className="text-base font-semibold sm:text-lg">
                       {user.name}

--- a/src/components/common/UserSelector.tsx
+++ b/src/components/common/UserSelector.tsx
@@ -1,0 +1,114 @@
+import { PostUsersSearch } from '@/api/users/post-user-search'
+import {
+  PostUserSearchReq,
+  PostUserSearchRes,
+  UserWithPhoneNumber,
+} from '@/types/auth'
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+import { ChangeEvent, useState } from 'react'
+import Divider from './Divider'
+import { CloseIcon } from '../icons'
+
+type Props = {
+  onClick?: (user: UserWithPhoneNumber) => void
+}
+
+const UserSelector = ({ onClick }: Props) => {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searchResults, setSearchResults] = useState<PostUserSearchRes>([])
+
+  const mutation = useMutation<
+    PostUserSearchRes,
+    AxiosError,
+    PostUserSearchReq
+  >({
+    mutationFn: PostUsersSearch,
+    onSuccess: (data) => {
+      setSearchResults(data)
+    },
+    onError: () => {
+      setSearchResults([])
+    },
+  })
+
+  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
+    const term = e.target.value
+    setSearchTerm(term)
+    if (term.length > 0) {
+      mutation.mutate({ keyword: term })
+    } else {
+      setSearchResults([])
+    }
+  }
+
+  return (
+    <div className="mx-auto">
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="이름, 전화번호, 이메일을 입력해주세요"
+          className="w-full rounded-md border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          value={searchTerm}
+          onChange={handleSearch}
+        />
+        <button
+          className="absolute right-3 top-2 rounded-full bg-neutral-300 sm:top-1"
+          onClick={() => {
+            setSearchTerm('')
+            setSearchResults([])
+          }}
+        >
+          <CloseIcon />
+        </button>
+      </div>
+      {searchResults && searchResults.length > 0 && (
+        <ul className="rounded-bl-md rounded-br-md border-b border-l border-r border-neutral-300 bg-white px-4 py-1 shadow-sm">
+          <div className="py-2 text-xs text-neutral-500">
+            💡 검색된 사용자 {searchResults.length} 명
+          </div>
+          <Divider />
+          <div>
+            {searchResults.map((user) => (
+              <li
+                key={user.userId}
+                className="flex cursor-pointer justify-between gap-2 py-3"
+              >
+                <div className="flex gap-2">
+                  <img
+                    src={user.profileImage}
+                    className="size-8 rounded-full object-cover sm:size-9"
+                  />
+                  <div className="flex items-center gap-1">
+                    <div className="text-base font-semibold sm:text-lg">
+                      {user.name}
+                    </div>
+                    <div className="text-[12px] text-neutral-500 sm:text-xs">
+                      {user.phoneNumber ? user.phoneNumber : user.email}
+                    </div>
+                  </div>
+                </div>
+                {onClick && (
+                  <button
+                    className="rounded bg-primary-500 px-2 py-1 text-xs text-white sm:text-base"
+                    onClick={() => onClick(user)}
+                  >
+                    <span>추가</span>
+                    <span className="hidden sm:inline">하기</span>
+                  </button>
+                )}
+              </li>
+            ))}
+          </div>
+        </ul>
+      )}
+      {!mutation.isIdle && !searchResults.length && (
+        <div className="px-2 py-1 text-sm text-red-400">
+          해당 사용자가 없습니다!
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default UserSelector

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -20,6 +20,7 @@ export const QUERY_KEYS = {
   GET_KAKAO_LOGIN: 'kakaoLogin',
   GET_NAVER_LOGIN: 'naverLogin',
   GET_USER_ME: 'me',
+  GET_USER_SEARCH: 'userSearch',
   GET_SCHEDULES: 'schedules',
   GET_SCHEDULE_BY_ID: 'scheduleById',
   GET_SCHEDULE_BY_RANGE: 'scheduleByRange',

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -38,3 +38,13 @@ export interface PostRefreshTokenRes {
 }
 
 export interface GetUsersMeRes extends IUser {}
+
+export interface PostUserSearchReq {
+  keyword: string
+}
+
+export interface UserWithPhoneNumber extends IUser {
+  phoneNumber: string
+}
+
+export interface PostUserSearchRes extends Array<UserWithPhoneNumber> {}


### PR DESCRIPTION
## ✅ 이슈 번호
#61 

## ✅ 작업 내용
- 사용자 검색 컴포넌트 `UserSelector` 추가

## ✅ 공유 사항
![user-selector-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/fc4c6ba3-e805-4f16-b5ad-22a7353a67e5)
- prop 으로 넘기는 `onClick` 함수에는 선택한 사용자의 정보가 인수로 사용됩니다. 

- 현재 찾는 사용자 정보가 DB에 없으면 404 에러를 return 하고 있습니다. (console창 또는 network를 확인해보시면 검색어 입력시마다 404가 return 되고 있음을 확인하실 수 있습니다.) 일치하는 사용자 정보가 없다고 하여 에러 코드를 반환할 필요는 없을 것 같아, 재우님께 status code를 요청 성공으로 바꾸고 대신 빈 배열을 response로 받을 수 있는지 문의 드려두었습니다.
