### PR TITLE
[FEAT] 일정 관련 타입 수정 및 format-phone-number util 추가

### DIFF
--- a/src/components/common/UserMiniProfile.tsx
+++ b/src/components/common/UserMiniProfile.tsx
@@ -1,5 +1,6 @@
 import { UserWithPhoneNumber } from '@/types/auth'
 import { cn } from '@/utils/cn'
+import { formatPhoneNumber } from '@/utils/format-phone-number'
 
 type Props = {
   user: UserWithPhoneNumber
@@ -22,7 +23,7 @@ const UserMiniProfile = ({ user, className }: Props) => {
       <div className="gqp-0 flex flex-col sm:flex-row sm:items-center sm:gap-1">
         <div className="text-sm font-semibold sm:text-base">{user.name}</div>
         <div className="text-[12px] text-neutral-500 sm:text-xs">
-          {user.phoneNumber ? user.phoneNumber : user.email}
+          {user.phoneNumber ? formatPhoneNumber(user.phoneNumber) : user.email}
         </div>
       </div>
     </div>

--- a/src/types/schedules.ts
+++ b/src/types/schedules.ts
@@ -21,9 +21,18 @@ export interface ISchedule {
   isAllDay: boolean
   scheduleId: number
   isRecurring: boolean
-  repeatType: RecurringOptionValue
-  recurringInterval: number
-  repeatEndDate: Date
+  repeatType?: RecurringOptionValue
+  recurringInterval?: number
+  repeatEndDate?: Date
+  recurringDaysOfWeek: number[]
+  recurringDayOfMonth: number
+  recurringMonthOfYear: number
+  groupInfo?: [
+    {
+      groupId: number
+      userUuids: string[]
+    },
+  ]
 }
 
 export interface IMediaAnalysisResult {
@@ -77,6 +86,12 @@ export interface PostSchedulesReq {
   recurringDaysOfWeek?: number[]
   recurringDaysOfMonth?: number[]
   recurringDayOfYear?: number[]
+  groupInfo?: [
+    {
+      groupId: number
+      userUuids: string[]
+    },
+  ]
 }
 
 export interface PostSchedulesRes extends PostSchedulesReq {

--- a/src/utils/format-phone-number.ts
+++ b/src/utils/format-phone-number.ts
@@ -1,0 +1,11 @@
+export const formatPhoneNumber = (phoneNumber: string): string => {
+  if (phoneNumber.length !== 11) {
+    return phoneNumber
+  }
+
+  const area = phoneNumber.slice(0, 3)
+  const front = phoneNumber.slice(3, 7)
+  const back = phoneNumber.slice(7)
+
+  return `${area}-${front}-${back}`
+}


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
- 일정 등록시 필요한 필드 입력들이 옵셔널하게 추가됨에 따라 타입을 추가하였습니다.
- 00000000000 형태로 들어오는 전화번호를 000-0000-0000 형태로 format 하기 위한 util 함수를 추가하였습니다.

## ✅ 공유 사항
