### PR TITLE
[FEAT] 피관리자 일정 조회 UI 추가 및 일정 폼 그룹, 반복 필드 삭제

### DIFF
--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -1,0 +1,75 @@
+import { ChangeEvent, useState } from 'react'
+import { PrevIcon } from '../icons'
+
+type Props = {
+  isSidebarOpen: boolean
+  toggleSidebar: () => void
+}
+
+interface User {
+  id: string
+  label: string
+}
+
+const users: User[] = [
+  { id: '1', label: '사용자1' },
+  { id: '2', label: '사용자2' },
+  { id: '3', label: '사용자3' },
+  { id: '4', label: '사용자4' },
+]
+
+const SideBar = ({ isSidebarOpen, toggleSidebar }: Props) => {
+  const [selectedSubotdinate, setSelectedSubordinate] = useState<string>('')
+
+  return (
+    <>
+      {isSidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black bg-opacity-50"
+          onClick={toggleSidebar}
+        ></div>
+      )}
+      <div
+        className={`fixed right-0 top-0 h-full w-[220px] transform bg-white shadow-lg transition-transform duration-300 ease-in-out sm:w-[30%] ${
+          isSidebarOpen ? 'z-50 translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <button onClick={toggleSidebar} className="mt-5 px-3">
+          <PrevIcon />
+        </button>
+        <div className="px-4 py-2">
+          <h2 className="mb-1 text-xl font-bold">관리인 일정</h2>
+          <button className="my-3 rounded border px-2 py-1 text-xs">
+            초기화
+          </button>
+          {users.map((task) => (
+            <label key={task.id} className="flex items-center space-x-2">
+              <input
+                type="radio"
+                name="task"
+                value={task.id}
+                checked={selectedSubotdinate === task.id}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setSelectedSubordinate(e.target.value)
+                }
+                className="form-radio text-green-500"
+              />
+              <span>{task.label}</span>
+            </label>
+          ))}
+          {selectedSubotdinate && (
+            <>
+              <p className="mt-4">선택된 사용자: </p>
+              <p>
+                {' '}
+                {users.find((task) => task.id === selectedSubotdinate)?.label}
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default SideBar

--- a/src/components/common/schedule-form/ScheduleForm.tsx
+++ b/src/components/common/schedule-form/ScheduleForm.tsx
@@ -6,7 +6,7 @@ import CategoryField from './field-components/CategoryField'
 import DownArrowIcon from '@/components/icons/DownArrowIcon'
 import { ISchedule, IScheduleForm } from '@/types/schedules'
 import TextAreaField from './field-components/TextAreaField'
-import GroupField from './field-components/GroupField'
+// import GroupField from './field-components/GroupField'
 import RepetitionField from './field-components/RepetitionField'
 
 type Props = {
@@ -94,7 +94,7 @@ const ScheduleForm = ({
                 placeholder="장소를 입력해주세요"
               />
 
-              <GroupField />
+              {/* <GroupField /> */}
               <RepetitionField />
 
               <TextAreaField

--- a/src/components/common/schedule-form/field-components/RepetitionField.tsx
+++ b/src/components/common/schedule-form/field-components/RepetitionField.tsx
@@ -1,63 +1,63 @@
-import Select, { components } from 'react-select'
-import BaseField from './BaseField'
-import { useState } from 'react'
-import { useModal } from '@/hooks/use-modal'
+// import Select, { components } from 'react-select'
+// import BaseField from './BaseField'
+// import { useState } from 'react'
+// import { useModal } from '@/hooks/use-modal'
 import { useFormContext } from 'react-hook-form'
-import RepititionSetModal from './RepititionSetModal'
-import { RecurringOptionValue } from '@/types/schedules'
+// import RepititionSetModal from './RepititionSetModal'
+// import { RecurringOptionValue } from '@/types/schedules'
 
-type RecurringOption = {
-  value: RecurringOptionValue
-  label: string
-}
+// type RecurringOption = {
+//   value: RecurringOptionValue
+//   label: string
+// }
 
-const options: RecurringOption[] = [
-  {
-    value: 'none',
-    label: '없음',
-  },
-  {
-    value: 'daily',
-    label: '일간 반복',
-  },
-  {
-    value: 'weekly',
-    label: '주간 반복',
-  },
-  {
-    value: 'monthly',
-    label: '월간 반복',
-  },
-  {
-    value: 'yearly',
-    label: '연간 반복',
-  },
-]
+// const options: RecurringOption[] = [
+//   {
+//     value: 'none',
+//     label: '없음',
+//   },
+//   {
+//     value: 'daily',
+//     label: '일간 반복',
+//   },
+//   {
+//     value: 'weekly',
+//     label: '주간 반복',
+//   },
+//   {
+//     value: 'monthly',
+//     label: '월간 반복',
+//   },
+//   {
+//     value: 'yearly',
+//     label: '연간 반복',
+//   },
+// ]
 
-const CustomPlaceholder = () => (
-  <div>
-    <span className="hidden sm:inline">반복</span>
-    <span> 선택</span>
-  </div>
-)
+// const CustomPlaceholder = () => (
+//   <div>
+//     <span className="hidden sm:inline">반복</span>
+//     <span> 선택</span>
+//   </div>
+// )
 
 const RepetitionField = () => {
-  const { isModalOpen, openModal, closeModal } = useModal()
-  const { setValue, watch } = useFormContext()
-  const [selected, setSelected] = useState<string>('')
-  const [repeatType, setRepeatType] = useState<RecurringOptionValue>('none')
+  // const { isModalOpen, openModal, closeModal } = useModal()
+  const { watch } = useFormContext()
+  // const [selected, setSelected] = useState<string>('')
+  // const [repeatType, setRepeatType] = useState<RecurringOptionValue>('none')
 
   // useEffect(() => {
   //   setValue('isRecurring', true);
   // }, [setValue])
 
   const isRecurring = watch('isRecurring')
-  const settedRepeatType = watch('repeatType')
+  // const settedRepeatType = watch('repeatType')
 
   return (
     <>
       <div className="hidden">{isRecurring}</div>
-      <div className="hidden">{settedRepeatType}</div>
+      {/* <div className="hidden">{settedRepeatType}</div>
       <BaseField
         id="repitition"
         label="반복"
@@ -158,7 +158,7 @@ const RepetitionField = () => {
           repeatType={repeatType}
           setSelected={setSelected}
         />
-      )}
+      )} */}
     </>
   )
 }

--- a/src/hooks/use-side-bar.ts
+++ b/src/hooks/use-side-bar.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react'
+
+export const useSideBar = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+
+  const handleSideBar = useCallback(() => {
+    setIsSidebarOpen((prev) => !prev)
+  }, [])
+
+  return { isSidebarOpen, handleSideBar }
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,15 +1,19 @@
+import SideBar from '@/components/common/SideBar'
 import CalendarView from '@/components/schedule/CalendarView'
 import DailyView from '@/components/schedule/DailyView'
 import Tabs from '@/components/schedule/Tabs'
+import { useSideBar } from '@/hooks/use-side-bar'
 import { TabEnum } from '@/types/common'
 import { useState } from 'react'
 
 const HomePage = () => {
   const [activeTab, setActiveTab] = useState<TabEnum>(TabEnum.Daily)
   const tabs = Object.values(TabEnum)
+  const { isSidebarOpen, handleSideBar } = useSideBar()
 
   return (
     <div className="flex flex-1 flex-col gap-y-5">
+      <button onClick={handleSideBar}>관리자</button>
       <Tabs<TabEnum>
         activeTab={activeTab}
         setActiveTab={setActiveTab}
@@ -19,6 +23,7 @@ const HomePage = () => {
       {activeTab === TabEnum.Daily && <DailyView />}
 
       {activeTab === TabEnum.Monthly && <CalendarView />}
+      <SideBar isSidebarOpen={isSidebarOpen} toggleSidebar={handleSideBar} />
     </div>
   )
 }

--- a/src/pages/create-schedule/CreateManualSchedulePage.tsx
+++ b/src/pages/create-schedule/CreateManualSchedulePage.tsx
@@ -40,6 +40,8 @@ const CreateManualSchedulePage = () => {
       ...data,
     } as PostSchedulesReq
 
+    console.log(payload)
+
     mutation.mutate(payload, {
       onSuccess: (response) => {
         console.log('일정 생성 성공:', response)


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
- 피관리자 일정 조회 UI 추가 하였습니다.
- 일정 폼에서 공유 그룹과 반복 필드를 주석하였습니다. `isRecurring=false` 를 유지하기 위해 `RepititionField`는 form 컴포넌트에서 주석 처리하는 대신, 개별 필드 컴포넌트 내에서 주석하였습니다.

## ✅ 공유 사항
