### PR TITLE
[FEAT] 그룹 테스트 의 수정사항

### DIFF
--- a/src/components/group/CreateGroupModal.tsx
+++ b/src/components/group/CreateGroupModal.tsx
@@ -8,9 +8,10 @@ import { toast } from 'react-toastify'
 import { useState } from 'react'
 import UserSelector from '../common/UserSelector'
 import { UserWithPhoneNumber } from '@/types/auth'
-import { AxiosError } from 'axios'
 import { useParams } from 'react-router-dom'
-import { GetGroupDetail } from '@/types/group'
+import { GetGroupDetail, PostGroupReq, PostGroupRes } from '@/types/group'
+import Toast from '../common/Toast'
+import { AxiosError } from 'axios'
 
 type Props = TModal & {
   isCreateGroup: boolean
@@ -26,7 +27,7 @@ const CreateGroupModal = ({ onClose, isCreateGroup, members }: Props) => {
   const { id } = useParams<{ id: string }>() // URL 파라미터 타입 지정
 
   // 그룹명 생성
-  const groupMutation = useMutation({
+  const groupMutation = useMutation<PostGroupRes, AxiosError, PostGroupReq>({
     mutationKey: [QUERY_KEYS.POST_GROUP],
     mutationFn: postGroup,
     onSuccess: (data) => {
@@ -34,13 +35,8 @@ const CreateGroupModal = ({ onClose, isCreateGroup, members }: Props) => {
       setIsCreateGroup(true)
       setGroupId(data.groupId)
     },
-    onError: (error: AxiosError) => {
-      console.log(error)
-      if (error.response && error.response.status === 400) {
-        toast.error('동일 그룹명을 가진 그룹에 소속되어 있습니다.')
-      } else {
-        toast.error('그룹 생성에 실패했습니다.')
-      }
+    onError: () => {
+      toast.error('동일 그룹명을 가진 그룹에 소속되어 있습니다.')
     },
   })
 
@@ -176,6 +172,7 @@ const CreateGroupModal = ({ onClose, isCreateGroup, members }: Props) => {
           </div>
         )}
       </div>
+      <Toast />
     </Modal>
   )
 }

--- a/src/components/group/GroupInvited.tsx
+++ b/src/components/group/GroupInvited.tsx
@@ -21,6 +21,8 @@ import {
   patchGroupCancel,
 } from '@/api/group/patch-group-invitation'
 import SendedInvitation from '../setting/SendedInvitation'
+import { toast } from 'react-toastify'
+import Toast from '../common/Toast'
 
 const GroupInvited = () => {
   const queryClient = useQueryClient()
@@ -46,8 +48,10 @@ const GroupInvited = () => {
   //받은 초대 거절
   const mutationReject = useMutation<PatchGroupRejectRes, Error, number>({
     mutationFn: (id: number) => patchGroupReject({ id }),
-    onSuccess: (data) => {
-      console.log('요청 거절 성공:', data)
+    onSuccess: () => {
+      toast.success('초대 요청 거절하였습니다.')
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.GET_GROUP_INVITATION_RECEIVED],
       })
@@ -57,8 +61,10 @@ const GroupInvited = () => {
   //받은 초대 수락
   const mutationAccept = useMutation<PatchGroupAcceptRes, Error, number>({
     mutationFn: (id: number) => patchGroupAccept({ id }),
-    onSuccess: (data) => {
-      console.log('요청 수락 성공:', data)
+    onSuccess: () => {
+      toast.success('초대 요청 수락하였습니다.')
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.GET_GROUP_INVITATION_RECEIVED],
       })
@@ -68,15 +74,15 @@ const GroupInvited = () => {
   //초대 철회
   const mutationCancel = useMutation<PatchGroupCancelRes, Error, number>({
     mutationFn: (id: number) => patchGroupCancel({ id }),
-    onSuccess: (data) => {
-      console.log('요청 수락 성공:', data)
+    onSuccess: () => {
+      toast.success('초대 요청 취소하였습니다.')
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.GET_GROUP_INVITATION_SEND],
       })
     },
   })
-
-  console.log(GroupInvitationReceived)
 
   const handleGroupReject = (id: number) => {
     mutationReject.mutate(id)
@@ -122,6 +128,7 @@ const GroupInvited = () => {
           </InvitationsSection>
         </div>
       </SettingSection>
+      <Toast />
     </div>
   )
 }

--- a/src/components/setting/ReceivedInvitation.tsx
+++ b/src/components/setting/ReceivedInvitation.tsx
@@ -38,8 +38,11 @@ const ReceivedInvitation = ({ item, onClickReject, onClickAccept }: Props) => {
   /* 그룹 dto에 맞게 수정해서 사용해주세요 */
   return (
     <div className="mb-1 flex items-center justify-between rounded bg-neutral-200 px-3 py-[7px]">
+      {!isManagerInvitation(item) && (
+        <div className="font-bold">{item.groupName}</div>
+      )}
       <div className="font-bold">
-        {isManagerInvitation(item) ? item.subordinateName : '그룹원 이름'}
+        {isManagerInvitation(item) ? item.subordinateName : item.inviterName}
       </div>
       <div className="flex gap-1">
         {item.status === 'PENDING' && (

--- a/src/components/setting/ReceivedInvitation.tsx
+++ b/src/components/setting/ReceivedInvitation.tsx
@@ -19,6 +19,22 @@ const ReceivedInvitation = ({ item, onClickReject, onClickAccept }: Props) => {
     ? item.managerInvitationId
     : item.invitationId
 
+  // 3분이 지나면 화면에 표시하지 않음
+  // let updatedAt: Date | undefined
+  // if (typeof item.updatedAt === 'string') {
+  //   updatedAt = new Date(item.updatedAt)
+  // } else {
+  //   updatedAt = item.updatedAt
+  // }
+  // const now = new Date()
+  // const threeMinutes = 3 * 60 * 1000
+  // const isExpired = updatedAt
+  //   ? now.getTime() - updatedAt.getTime() > threeMinutes
+  //   : false
+  // if (item.status === 'CANCELED' && isExpired) {
+  //   return null
+  // }
+
   /* 그룹 dto에 맞게 수정해서 사용해주세요 */
   return (
     <div className="mb-1 flex items-center justify-between rounded bg-neutral-200 px-3 py-[7px]">

--- a/src/components/setting/SendedInvitation.tsx
+++ b/src/components/setting/SendedInvitation.tsx
@@ -38,7 +38,7 @@ const SendedInvitation = ({ item, onClickReject }: Props) => {
   return (
     <div className="mb-1 flex justify-between rounded bg-neutral-200 px-3 py-[7px]">
       <div className="font-bold">
-        {isManagerInvitation(item) ? item.subordinateName : '그룹원 이름'}
+        {isManagerInvitation(item) ? item.subordinateName : item.inviteeName}
       </div>
       <div className="flex gap-1">
         {item.status === 'PENDING' && (

--- a/src/components/setting/SendedInvitation.tsx
+++ b/src/components/setting/SendedInvitation.tsx
@@ -18,6 +18,22 @@ const SendedInvitation = ({ item, onClickReject }: Props) => {
     ? item.managerInvitationId
     : item.invitationId
 
+  // 3분이 지나면 화면에 표시하지 않음
+  // let updatedAt: Date | undefined
+  // if (typeof item.updatedAt === 'string') {
+  //   updatedAt = new Date(item.updatedAt)
+  // } else {
+  //   updatedAt = item.updatedAt
+  // }
+  // const now = new Date()
+  // const threeMinutes = 3 * 60 * 1000
+  // const isExpired = updatedAt
+  //   ? now.getTime() - updatedAt.getTime() > threeMinutes
+  //   : false
+  // if (item.status === 'CANCELED' && isExpired) {
+  //   return null
+  // }
+
   /* 그룹 dto에 맞게 수정해서 사용해주세요 */
   return (
     <div className="mb-1 flex justify-between rounded bg-neutral-200 px-3 py-[7px]">

--- a/src/hooks/use-mypage.ts
+++ b/src/hooks/use-mypage.ts
@@ -13,11 +13,14 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.PUT_MYPAGE],
     mutationFn: putMypage,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PUT_MYPAGE] })
+      toast.success('수정되었습니다.')
     },
     onError: (err) => {
       console.log(err)
       toast.error(err.message)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PUT_MYPAGE] })
     },
   })
 
@@ -25,7 +28,7 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.POST_SMS_SEND],
     mutationFn: postSmsCode,
     onSuccess: () => {
-      toast.success('인증번호가 발송되었습니다. 5분 이내에 인증해주세요')
+      toast.success('인증번호가 발송되었습니다. 5분 이내에 인증해주세요.')
     },
     onError: (err) => {
       console.log(err)
@@ -36,7 +39,7 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.POST_SMS_VERIFY],
     mutationFn: postSmsVerify,
     onSuccess: () => {
-      toast.success('인증 완료되었습니다')
+      toast.success('인증 완료되었습니다.')
     },
     onError: (err) => {
       console.log(err)
@@ -47,7 +50,7 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.POST_EMAIL_SEND],
     mutationFn: postEmailSend,
     onSuccess: () => {
-      toast.success('인증번호가 발송되었습니다.\n 5분 이내에 인증해주세요')
+      toast.success('인증번호가 발송되었습니다.\n 5분 이내에 인증해주세요.')
     },
     onError: (err) => {
       console.log(err)
@@ -58,7 +61,7 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.POST_EMAIL_VERIFY],
     mutationFn: postEmailVerify,
     onSuccess: () => {
-      toast.success('인증 완료되었습니다')
+      toast.success('인증 완료되었습니다.')
     },
     onError: (err) => {
       console.log(err)
@@ -69,8 +72,7 @@ export const useMypageMutations = () => {
     mutationKey: [QUERY_KEYS.DELETE_USER],
     mutationFn: deleteUser,
     onSuccess: () => {
-      toast.success('삭제 성공')
-      // 추가적인 성공 후 작업 (예: 로그아웃)
+      localStorage.clear()
     },
     onError: () => {
       toast.error('유저 삭제에 실패했습니다.')

--- a/src/hooks/use-mypage.ts
+++ b/src/hooks/use-mypage.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { postEmailSend, postEmailVerify } from '@/api/mypage/post-mypage-auth'
+import { deleteUser, putMypage } from '@/api/mypage/put-mypage'
+import { postSmsCode } from '@/api/auth/post-sms-code'
+import { postSmsVerify } from '@/api/auth/post-sms-verify'
+import { QUERY_KEYS } from '@/constants/api'
+import { toast } from 'react-toastify'
+
+export const useMypageMutations = () => {
+  const queryClient = useQueryClient()
+
+  const mutationPutMypage = useMutation({
+    mutationKey: [QUERY_KEYS.PUT_MYPAGE],
+    mutationFn: putMypage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PUT_MYPAGE] })
+    },
+    onError: (err) => {
+      console.log(err)
+      toast.error(err.message)
+    },
+  })
+
+  const mutationSmsSend = useMutation({
+    mutationKey: [QUERY_KEYS.POST_SMS_SEND],
+    mutationFn: postSmsCode,
+    onSuccess: () => {
+      toast.success('인증번호가 발송되었습니다. 5분 이내에 인증해주세요')
+    },
+    onError: (err) => {
+      console.log(err)
+    },
+  })
+
+  const mutationSmsVerify = useMutation({
+    mutationKey: [QUERY_KEYS.POST_SMS_VERIFY],
+    mutationFn: postSmsVerify,
+    onSuccess: () => {
+      toast.success('인증 완료되었습니다')
+    },
+    onError: (err) => {
+      console.log(err)
+    },
+  })
+
+  const mutationEmailSend = useMutation({
+    mutationKey: [QUERY_KEYS.POST_EMAIL_SEND],
+    mutationFn: postEmailSend,
+    onSuccess: () => {
+      toast.success('인증번호가 발송되었습니다.\n 5분 이내에 인증해주세요')
+    },
+    onError: (err) => {
+      console.log(err)
+    },
+  })
+
+  const mutationEmailVerify = useMutation({
+    mutationKey: [QUERY_KEYS.POST_EMAIL_VERIFY],
+    mutationFn: postEmailVerify,
+    onSuccess: () => {
+      toast.success('인증 완료되었습니다')
+    },
+    onError: (err) => {
+      console.log(err)
+    },
+  })
+
+  const mutationDeleteUser = useMutation({
+    mutationKey: [QUERY_KEYS.DELETE_USER],
+    mutationFn: deleteUser,
+    onSuccess: () => {
+      toast.success('삭제 성공')
+      // 추가적인 성공 후 작업 (예: 로그아웃)
+    },
+    onError: () => {
+      toast.error('유저 삭제에 실패했습니다.')
+    },
+  })
+
+  return {
+    mutationPutMypage,
+    mutationSmsSend,
+    mutationSmsVerify,
+    mutationEmailSend,
+    mutationEmailVerify,
+    mutationDeleteUser,
+  }
+}

--- a/src/pages/setting/MyPage.tsx
+++ b/src/pages/setting/MyPage.tsx
@@ -1,11 +1,7 @@
-import { postEmailSend, postEmailVerify } from '@/api/mypage/post-mypage-auth'
-import { deleteUser, putMypage } from '@/api/mypage/put-mypage'
 import { Button } from '@/components/common'
-import { QUERY_KEYS } from '@/constants/api'
 import { useUser } from '@/hooks/use-user'
 import { path } from '@/routes/path'
 import { PutMypage } from '@/types/auth'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
@@ -15,12 +11,11 @@ import Modal from '@/components/common/Modal'
 import { useModal } from '@/hooks/use-modal'
 import Divider from '@/components/common/Divider'
 import TrashCanIcon from '@/components/icons/TrashCanIcon'
-import { postSmsCode } from '@/api/auth/post-sms-code'
-import { postSmsVerify } from '@/api/auth/post-sms-verify'
+import { formatPhoneNumber } from '@/utils/format-phone-number'
+import { useMypageMutations } from '@/hooks/use-mypage'
 
 const MyPage = () => {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { isModalOpen, openModal, closeModal } = useModal()
   const [isEdit, setIsEdit] = useState<boolean>(false)
   const [isSMSSent, setIsSMSSent] = useState<boolean>(false)
@@ -38,6 +33,15 @@ const MyPage = () => {
   const userInfo = user.info
   const phoneRegex = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/
 
+  const {
+    mutationPutMypage,
+    mutationSmsSend,
+    mutationSmsVerify,
+    mutationEmailSend,
+    mutationEmailVerify,
+    mutationDeleteUser,
+  } = useMypageMutations()
+
   useEffect(() => {
     if (isEdit) {
       setName('')
@@ -47,78 +51,42 @@ const MyPage = () => {
     }
   }, [isEdit])
 
-  //정보 수정
-  const mutation = useMutation({
-    mutationKey: [QUERY_KEYS.PUT_MYPAGE],
-    mutationFn: putMypage,
-    onSuccess: () => {
-      setIsEdit(false)
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PUT_MYPAGE] })
-      window.location.reload()
-    },
-    onError: (err) => {
-      console.log(err)
-      toast.error(err.message)
-    },
-  })
-
   const handlePutMy = () => {
     const payload: PutMypage = {}
-
-    // 전화번호 형식 검사
-    if (!phoneRegex.test(phoneNumber)) {
-      toast.error('전화번호 형식이 틀렸습니다. 올바른 형식으로 입력해 주세요.')
-      return
-    }
-
-    if (!payload.phoneVerificationCode || !payload.emailVerificationCode) {
-      toast.error('인증 후 수정할 수 있습니다')
-      return
-    }
 
     // 변경된 필드만
     if (name) payload.name = name
     if (phoneNumber) {
+      // 전화번호 형식 검사
+      if (!phoneRegex.test(phoneNumber)) {
+        toast.error(
+          '전화번호 형식이 틀렸습니다. 올바른 형식으로 입력해 주세요.'
+        )
+        return
+      }
+      if (!payload.phoneVerificationCode) {
+        toast.error('인증 후 수정할 수 있습니다')
+        return
+      }
       payload.phoneNumber = phoneNumber
       payload.phoneVerificationCode = smsVerify
     }
     if (email) {
+      if (!payload.emailVerificationCode) {
+        toast.error('인증 후 수정할 수 있습니다')
+        return
+      }
       payload.email = email
       payload.emailVerificationCode = emailVerify
     }
     if (address) payload.address = address
 
     if (Object.keys(payload).length > 0) {
-      mutation.mutate(payload)
+      mutationPutMypage.mutate(payload)
     } else {
       toast.error('변경된 값이 없습니다.')
     }
   }
-
-  //전화번호 인증
-  const smsSendMutation = useMutation({
-    mutationKey: [QUERY_KEYS.POST_SMS_SEND],
-    mutationFn: postSmsCode,
-    onSuccess: () => {
-      toast.success('인증번호가 발송되었습니다. 5분 이내에 인증해주세요')
-      setIsSMSSent(true)
-    },
-    onError: (err) => {
-      console.log(err)
-    },
-  })
-
-  const smsVerifyMutation = useMutation({
-    mutationKey: [QUERY_KEYS.POST_SMS_VERIFY],
-    mutationFn: postSmsVerify,
-    onSuccess: () => {
-      toast.success('인증 완료되었습니다')
-      setIsSMSSent(false)
-    },
-    onError: (err) => {
-      console.log(err)
-    },
-  })
 
   const handleSMSSend = () => {
     if (!phoneNumber) {
@@ -131,11 +99,14 @@ const MyPage = () => {
       toast.error(
         '전화번호 형식이 틀렸습니다.\n 올바른 형식으로 입력해 주세요.'
       )
+      console.log(phoneNumber)
+
       return
     }
 
     const payload = { phoneNumber: phoneNumber }
-    smsSendMutation.mutate(payload)
+    mutationSmsSend.mutate(payload)
+    setIsSMSSent(true)
   }
 
   const handleSMSVerify = () => {
@@ -144,33 +115,8 @@ const MyPage = () => {
       return
     }
     const payload = { phoneNumber: phoneNumber, code: smsVerify }
-    smsVerifyMutation.mutate(payload)
+    mutationSmsVerify.mutate(payload)
   }
-
-  //이메일 인증
-  const emailSendMutation = useMutation({
-    mutationKey: [QUERY_KEYS.POST_EMAIL_SEND],
-    mutationFn: postEmailSend,
-    onSuccess: () => {
-      toast.success('인증번호가 발송되었습니다.\n 5분 이내에 인증해주세요')
-      setIsEmailSent(true)
-    },
-    onError: (err) => {
-      console.log(err)
-    },
-  })
-
-  const emailVerifyMutation = useMutation({
-    mutationKey: [QUERY_KEYS.POST_EMAIL_VERIFY],
-    mutationFn: postEmailVerify,
-    onSuccess: () => {
-      toast.success('인증 완료되었습니다')
-      setIsEmailSent(false)
-    },
-    onError: (err) => {
-      console.log(err)
-    },
-  })
 
   const handleEmailSend = () => {
     if (!email) {
@@ -178,7 +124,8 @@ const MyPage = () => {
       return
     }
     const payload = { email: email }
-    emailSendMutation.mutate(payload)
+    mutationEmailSend.mutate(payload)
+    setIsEmailSent(true)
   }
 
   const handleEmailVerify = () => {
@@ -187,25 +134,11 @@ const MyPage = () => {
       return
     }
     const payload = { email: phoneNumber, code: emailVerify }
-    emailVerifyMutation.mutate(payload)
+    mutationEmailVerify.mutate(payload)
   }
 
-  //회원탈퇴
-  const userDeleteMutation = useMutation({
-    mutationKey: [QUERY_KEYS.DELETE_USER],
-    mutationFn: deleteUser,
-    onSuccess: () => {
-      console.log('삭제 성공')
-      navigate(`${path.login}`)
-      localStorage.clear()
-    },
-    onError: () => {
-      toast.error('유저 삭제에 실패했습니다.')
-    },
-  })
-
   const handleDeleteUser = () => {
-    userDeleteMutation.mutate()
+    mutationDeleteUser.mutate()
   }
   return (
     <div className="h-full w-full p-4">
@@ -307,7 +240,9 @@ const MyPage = () => {
               </>
             ) : (
               <p className="mt-2 text-xl">
-                {userInfo?.phoneNumber || '정보 없음'}
+                {userInfo?.phoneNumber
+                  ? formatPhoneNumber(userInfo.phoneNumber)
+                  : '정보 없음'}
               </p>
             )}
           </div>
@@ -349,7 +284,7 @@ const MyPage = () => {
                 )}
               </>
             ) : (
-              <p className="mt-2 text-xl">{userInfo?.email}</p>
+              <p className="mt-2 text-xl">{userInfo?.email || '정보 없음'}</p>
             )}
           </div>
           <div className="mb-4">

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -59,8 +59,10 @@ const SettingManagerPage = () => {
     number
   >({
     mutationFn: (id: number) => patchManagerReject(id),
-    onSuccess: (data) => {
-      console.log('요청 거절 성공:', data)
+    onSuccess: () => {
+      toast.success('초대 요청 거절하였습니다.')
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
       })
@@ -75,8 +77,10 @@ const SettingManagerPage = () => {
   const mutationAccept = useMutation<IPatchManagerInvitationRes, Error, number>(
     {
       mutationFn: (id: number) => patchManagerAccept(id),
-      onSuccess: (data) => {
-        console.log('요청 수락 성공:', data)
+      onSuccess: () => {
+        toast.success('초대 요청 수락하였습니다.')
+      },
+      onSettled: () => {
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
         })
@@ -92,8 +96,10 @@ const SettingManagerPage = () => {
   const mutationCancel = useMutation<IPatchManagerInvitationRes, Error, number>(
     {
       mutationFn: (id: number) => patchManagerCancel(id),
-      onSuccess: (data) => {
-        console.log('요청 철회 성공:', data)
+      onSuccess: () => {
+        toast.success('초대 요청 취소하였습니다.')
+      },
+      onSettled: () => {
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
         })
@@ -111,14 +117,16 @@ const SettingManagerPage = () => {
     mutationFn: postManagerInvitation,
     onSuccess: () => {
       closeModal()
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
-      })
       toast.success('초대에 성공했습니다!')
     },
     onError: () => {
       closeModal()
       toast.error('초대할 수 없는 사용자입니다.')
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
+      })
     },
   })
 

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -36,6 +36,8 @@ export interface GetGroupInvitationRes {
   invitationId: number
   status: string
   inviterUuid: string
+  createdAt?: Date
+  updatedAt?: Date
 }
 
 export interface PatchGroupRejectRes extends GetGroupInvitationRes {}

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -31,13 +31,16 @@ export enum GroupInvitationEnum {
 }
 
 export interface GetGroupInvitationRes {
-  groupId: number
-  inviteeUuid: string
   invitationId: number
-  status: string
+  groupId: number
+  groupName: string
   inviterUuid: string
+  inviterName: string
+  inviteeUuid: string
+  inviteeName: string
   createdAt?: Date
   updatedAt?: Date
+  status: string
 }
 
 export interface PatchGroupRejectRes extends GetGroupInvitationRes {}


### PR DESCRIPTION
## ✅ 이슈 번호
#84 세팅 테스트 수정사항

## ✅ 작업 내용
- 마이페이지 invalidateQueries
- 마이페이지 쿼리들 훅으로 분리
- 그룹생성 에러시 toast 메시지
- 보낸초대 CANCELED 상태일 시 3분 초과되면 화면에서 ui 보여주지 않도록 처리함

## ✅ 공유 사항
- 현재 전화번호 로그인이 안되던데 저만 그런가요?
- 보낸초대 화면에 안보여주는 코드 주석처리해두었습니다. 필요하다고 생각되면 댓글달아주세요. 주석 해제 후 사용하면 됩니다