### PR TITLE
[FEAT] 관리자 기능 전반 및 관리자 일정 조회 기능 추가

### DIFF
--- a/src/api/manager/delete-manager.ts
+++ b/src/api/manager/delete-manager.ts
@@ -1,0 +1,10 @@
+import { baseAPI } from '../axios-instance'
+import { API_DOMAINS } from '@/constants/api'
+
+export const deleteManager = async (uuid: string) => {
+  const { data } = await baseAPI.delete(
+    `${API_DOMAINS.MANAGER}/subordinate/${uuid}`
+  )
+
+  return data
+}

--- a/src/api/manager/delete-manager.ts
+++ b/src/api/manager/delete-manager.ts
@@ -3,7 +3,7 @@ import { API_DOMAINS } from '@/constants/api'
 
 export const deleteManager = async (uuid: string) => {
   const { data } = await baseAPI.delete(
-    `${API_DOMAINS.MANAGER}/subordinate/${uuid}`
+    `${API_DOMAINS.MANAGER}/manager/${uuid}`
   )
 
   return data

--- a/src/api/manager/delete-subordinate.ts
+++ b/src/api/manager/delete-subordinate.ts
@@ -1,0 +1,10 @@
+import { baseAPI } from '../axios-instance'
+import { API_DOMAINS } from '@/constants/api'
+
+export const deleteSubordinate = async (uuid: string) => {
+  const { data } = await baseAPI.delete(
+    `${API_DOMAINS.MANAGER}/subordinate/${uuid}`
+  )
+
+  return data
+}

--- a/src/api/manager/get-my-managers.ts
+++ b/src/api/manager/get-my-managers.ts
@@ -1,0 +1,11 @@
+import { baseAPI } from '../axios-instance'
+import { API_DOMAINS } from '@/constants/api'
+import { IGetMyManagersRes } from '@/types/manager'
+
+export const getMyManagers = async () => {
+  const { data } = await baseAPI.get<IGetMyManagersRes>(
+    `${API_DOMAINS.MANAGER}/managers`
+  )
+
+  return data
+}

--- a/src/api/manager/get-my-subordinates.ts
+++ b/src/api/manager/get-my-subordinates.ts
@@ -1,0 +1,11 @@
+import { baseAPI } from '../axios-instance'
+import { API_DOMAINS } from '@/constants/api'
+import { IGetMySubordinatesRes } from '@/types/manager'
+
+export const getMySubordinates = async () => {
+  const { data } = await baseAPI.get<IGetMySubordinatesRes>(
+    `${API_DOMAINS.MANAGER}/subordinates`
+  )
+
+  return data
+}

--- a/src/api/schedules/get-schedule-by-month.ts
+++ b/src/api/schedules/get-schedule-by-month.ts
@@ -2,13 +2,28 @@ import { GetSchedulesRes } from '@/types/schedules'
 import { baseAPI } from '../axios-instance'
 import { API_DOMAINS } from '@/constants/api'
 
-export const getScheduleByMonth = async (year: number, month: number) => {
+export const getScheduleByMonth = async (
+  year: number,
+  month: number,
+  userUuid?: string
+) => {
+  const params: { year: number; month: number; userUuid?: string } = {
+    year,
+    month,
+  }
+
+  if (userUuid) {
+    params.userUuid = userUuid
+  }
+
   const { data } = await baseAPI.get<GetSchedulesRes>(
     `${API_DOMAINS.SCHEDULES}/month`,
     {
-      params: { year, month },
+      params,
     }
   )
+
+  return data
 
   return data
 }

--- a/src/api/schedules/get-schedule-by-range.ts
+++ b/src/api/schedules/get-schedule-by-range.ts
@@ -4,12 +4,22 @@ import { API_DOMAINS } from '@/constants/api'
 
 export const getScheduleByRange = async (
   startDate: string,
-  endDate: string
+  endDate: string,
+  userUuid?: string
 ) => {
+  const params: { startDate: string; endDate: string; userUuid?: string } = {
+    startDate,
+    endDate,
+  }
+
+  if (userUuid) {
+    params.userUuid = userUuid
+  }
+
   const { data } = await baseAPI.get<GetSchedulesRes>(
     `${API_DOMAINS.SCHEDULES}/range`,
     {
-      params: { startDate, endDate },
+      params,
     }
   )
 

--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -1,25 +1,19 @@
-import { ChangeEvent, useState } from 'react'
 import { PrevIcon } from '../icons'
+import { useManager } from '@/hooks/use-manager'
+import useManagerStore from '@/store/manager'
 
 type Props = {
   isSidebarOpen: boolean
   toggleSidebar: () => void
 }
 
-interface User {
-  id: string
-  label: string
-}
-
-const users: User[] = [
-  { id: '1', label: '사용자1' },
-  { id: '2', label: '사용자2' },
-  { id: '3', label: '사용자3' },
-  { id: '4', label: '사용자4' },
-]
-
 const SideBar = ({ isSidebarOpen, toggleSidebar }: Props) => {
-  const [selectedSubotdinate, setSelectedSubordinate] = useState<string>('')
+  const { selectedSubordinate, setSelectedSubordinate } = useManagerStore()
+  const { mySubordinates } = useManager()
+
+  const handleReset = () => {
+    setSelectedSubordinate(null)
+  }
 
   return (
     <>
@@ -38,34 +32,80 @@ const SideBar = ({ isSidebarOpen, toggleSidebar }: Props) => {
           <PrevIcon />
         </button>
         <div className="px-4 py-2">
-          <h2 className="mb-1 text-xl font-bold">관리인 일정</h2>
-          <button className="my-3 rounded border px-2 py-1 text-xs">
-            초기화
+          <h2 className="text-xl font-bold">관리인 일정 관리</h2>
+          <div className="text-[10px]">
+            💡피관리인들의 일정을 관리할 수 있습니다.
+          </div>
+          <button
+            onClick={handleReset}
+            className="my-3 w-full rounded border px-2 py-1 text-xs"
+          >
+            설정 초기화
           </button>
-          {users.map((task) => (
-            <label key={task.id} className="flex items-center space-x-2">
-              <input
-                type="radio"
-                name="task"
-                value={task.id}
-                checked={selectedSubotdinate === task.id}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setSelectedSubordinate(e.target.value)
-                }
-                className="form-radio text-green-500"
-              />
-              <span>{task.label}</span>
-            </label>
-          ))}
-          {selectedSubotdinate && (
+
+          <div className="pt-3 font-semibold">🍀 선택된 사용자</div>
+          {selectedSubordinate && (
             <>
-              <p className="mt-4">선택된 사용자: </p>
-              <p>
-                {' '}
-                {users.find((task) => task.id === selectedSubotdinate)?.label}
-              </p>
+              <div className="mx-2 mb-1 mt-3 flex">
+                {selectedSubordinate?.profileImage ? (
+                  <img
+                    src={selectedSubordinate.profileImage}
+                    className="size-6 rounded-full object-cover sm:size-9"
+                  />
+                ) : (
+                  <div className="flex size-6 items-center justify-center rounded-full border text-[13px] sm:size-6 sm:text-[15px]">
+                    {selectedSubordinate.name[0]}
+                  </div>
+                )}
+                <p className="px-2 pb-1">
+                  {
+                    mySubordinates.find(
+                      (task) => task.userUuid === selectedSubordinate.userUuid
+                    )?.name
+                  }
+                </p>
+              </div>
             </>
           )}
+          {!selectedSubordinate && (
+            <div className="my-2 flex h-10 items-center justify-center rounded border text-[13px] text-neutral-400">
+              선택된 사용자가 없습니다.
+            </div>
+          )}
+
+          <div>
+            <div className="flex gap-2">
+              <div className="pt-3 font-semibold">🍀 피관리인 목록</div>
+              <p className="pt-3 text-[11px] text-neutral-500">
+                총 {mySubordinates?.length}명
+              </p>
+            </div>
+            <div className="px-2 py-2">
+              {mySubordinates.map((user) => (
+                <label
+                  key={user.userUuid}
+                  className="flex items-center space-x-2"
+                >
+                  <input
+                    type="radio"
+                    name="task"
+                    value={user.userUuid}
+                    checked={selectedSubordinate?.userUuid === user.userUuid}
+                    onChange={(e) => {
+                      const selectedUser = mySubordinates.find(
+                        (sub) => sub.userUuid === e.target.value
+                      )
+                      if (selectedUser) {
+                        setSelectedSubordinate(selectedUser)
+                      }
+                    }}
+                    className="form-radio text-green-500"
+                  />
+                  <span>{user.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/icons/ManagerIcon.tsx
+++ b/src/components/icons/ManagerIcon.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { cn } from '@/utils/cn'
+
+const ManagerIcon = ({ className, ...props }: React.ComponentProps<'svg'>) => {
+  return (
+    <svg
+      width="64px"
+      height="64px"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn('h-6 w-6 sm:h-8 sm:w-8', className)}
+      {...props}
+    >
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g
+        id="SVGRepo_tracerCarrier"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></g>
+      <g id="SVGRepo_iconCarrier">
+        <path
+          fill="currentColor"
+          d="M1 21h22V3H1zm1-1V7h20v13zM22 4v2H2V4zM9.355 13.16a2.5 2.5 0 1 0-3.71 0A2.496 2.496 0 0 0 4 15.5V18h7v-2.5a2.496 2.496 0 0 0-1.645-2.34zM7.5 10A1.5 1.5 0 1 1 6 11.5 1.502 1.502 0 0 1 7.5 10zm2.5 7H5v-1.5A1.502 1.502 0 0 1 6.5 14h2a1.502 1.502 0 0 1 1.5 1.5zm3-7h7v1h-7zm0 3h7v1h-7zm1 3h5v1h-5z"
+        ></path>
+        <path fill="none" d="M0 0h24v24H0z"></path>
+      </g>
+    </svg>
+  )
+}
+
+export default ManagerIcon

--- a/src/components/icons/RefreshIcon.tsx
+++ b/src/components/icons/RefreshIcon.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { cn } from '@/utils/cn'
+
+const RefreshIcon = ({ className, ...props }: React.ComponentProps<'svg'>) => {
+  return (
+    <svg
+      width="64px"
+      height="64px"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn('h-5 w-5', className)}
+      {...props}
+    >
+      <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+      <g
+        id="SVGRepo_tracerCarrier"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      ></g>
+      <g id="SVGRepo_iconCarrier">
+        <path
+          fill="currentColor"
+          d="M22.719 12A10.719 10.719 0 0 1 1.28 12h.838a9.916 9.916 0 1 0 1.373-5H8v1H2V2h1v4.2A10.71 10.71 0 0 1 22.719 12z"
+        ></path>
+        <path fill="none" d="M0 0h24v24H0z"></path>
+      </g>
+    </svg>
+  )
+}
+
+export default RefreshIcon

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,28 +5,55 @@ import { Link } from 'react-router-dom'
 import { IconButton } from '../common'
 import Notification from '../common/notification/Notification'
 import { InfoIcon } from '../icons'
+import { useManager } from '@/hooks/use-manager'
+import ManagerIcon from '../icons/ManagerIcon'
+import { useSideBar } from '@/hooks/use-side-bar'
+import SideBar from '../common/SideBar'
 
 const Header = () => {
+  const { hasSubordinates } = useManager()
+  const { isSidebarOpen, handleSideBar } = useSideBar()
+
   return (
-    <header
-      className={cn(
-        'flex items-center justify-between border-b border-neutral-200 px-3 py-2',
-        'sticky top-0 z-30 bg-white'
-      )}
-    >
-      <Link to={path.schedules}>
-        <img src={logo} alt="Logo" className="sm:h-15 h-8 w-40 sm:w-[200px]" />
-      </Link>
-      <div className="flex items-center">
-        <IconButton
-          direction="vertical"
-          icon={<InfoIcon />}
-          text="도움말"
-          className="mr-4 text-nowrap text-sm"
-        />
-        <Notification />
-      </div>
-    </header>
+    <>
+      <header
+        className={cn(
+          'flex items-center justify-between border-b border-neutral-200 px-3 py-2',
+          'sticky top-0 z-30 bg-white'
+        )}
+      >
+        <Link to={path.schedules}>
+          <img
+            src={logo}
+            alt="Logo"
+            className="sm:h-15 h-8 w-40 sm:w-[200px]"
+          />
+        </Link>
+        <div className="flex items-center">
+          <IconButton
+            direction="vertical"
+            icon={<InfoIcon />}
+            text="도움말"
+            className="mr-4 text-nowrap text-sm"
+          />
+          <Notification />
+          {hasSubordinates && (
+            <button
+              onClick={handleSideBar}
+              className="ml-[16px] flex items-center"
+            >
+              <IconButton
+                direction="vertical"
+                icon={<ManagerIcon className="w-6 sm:w-11" />}
+                text="관리자"
+                className="mr-4 mt-[3px] text-nowrap text-sm"
+              />
+            </button>
+          )}
+        </div>
+      </header>
+      <SideBar isSidebarOpen={isSidebarOpen} toggleSidebar={handleSideBar} />
+    </>
   )
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -34,21 +34,21 @@ const Header = () => {
             direction="vertical"
             icon={<InfoIcon />}
             text="도움말"
-            className="mr-4 text-nowrap text-sm"
+            className="mr-2 text-nowrap text-sm"
           />
           <Notification />
           {hasSubordinates && (
-            <button
+            <div
               onClick={handleSideBar}
-              className="ml-[16px] flex items-center"
+              className="ml-[10px] flex items-center"
             >
               <IconButton
                 direction="vertical"
                 icon={<ManagerIcon className="w-6 sm:w-11" />}
                 text="관리자"
-                className="mr-4 mt-[3px] text-nowrap text-sm"
+                className="mt-[3px] text-nowrap text-sm"
               />
-            </button>
+            </div>
           )}
         </div>
       </header>

--- a/src/components/schedule/CalendarView.tsx
+++ b/src/components/schedule/CalendarView.tsx
@@ -17,17 +17,20 @@ import { formatDate } from '@/utils/format-date'
 import { DateFormatTypeEnum } from '@/types/common'
 import { useRangeSchedule } from '@/hooks/use-range-schedule'
 import Divider from '../common/Divider'
+import useManagerStore from '@/store/manager'
 
 const CalendarView = () => {
   const [currentDate, setCurrentDate] = useState<Date | undefined>(undefined)
   const [currentMonth, setCurrentMonth] = useState(new Date())
+  const { selectedSubordinate } = useManagerStore()
 
   const monthStart = startOfMonth(currentMonth)
   const monthEnd = endOfMonth(currentMonth)
 
   const { data: schedules, isSchedule } = useRangeSchedule(
     formatDate(DateFormatTypeEnum.DateWithHypen, monthStart),
-    formatDate(DateFormatTypeEnum.DateWithHypen, monthEnd)
+    formatDate(DateFormatTypeEnum.DateWithHypen, monthEnd),
+    selectedSubordinate?.userUuid
   )
 
   const { rows } = useCalendar({ setCurrentDate, currentMonth, isSchedule })

--- a/src/components/schedule/DailyView.tsx
+++ b/src/components/schedule/DailyView.tsx
@@ -16,16 +16,27 @@ import {
 import { useState } from 'react'
 import EventContainer from './EventContainer'
 import WeekdaySelector from './WeekdaySelector'
+import useManagerStore from '@/store/manager'
 
 const DailyView = () => {
   const { user, isUserLoading } = useUser()
+  const { selectedSubordinate } = useManagerStore()
 
   const [selectedDate, setSelectedDate] = useState<Date>(startOfDay(new Date()))
   const selectedMonth = getMonth(addMonths(selectedDate, 1))
 
   const { isLoading, data } = useQuery<GetSchedulesRes>({
-    queryKey: [QUERY_KEYS.GET_SCHEDULE_BY_RANGE, selectedMonth],
-    queryFn: () => getScheduleByMonth(getYear(selectedDate), selectedMonth),
+    queryKey: [
+      QUERY_KEYS.GET_SCHEDULE_BY_RANGE,
+      selectedMonth,
+      selectedSubordinate,
+    ],
+    queryFn: () =>
+      getScheduleByMonth(
+        getYear(selectedDate),
+        selectedMonth,
+        selectedSubordinate?.userUuid
+      ),
     enabled: !isUserLoading && !!user.info?.userUuid,
   })
 

--- a/src/components/setting/InvitationLayout.tsx
+++ b/src/components/setting/InvitationLayout.tsx
@@ -1,11 +1,19 @@
 import { GetGroupInvitationRes } from '@/types/group'
-import { IGetManagerInvitationRes } from '@/types/manager'
+import {
+  IGetManagerInvitationRes,
+  IGetMyManagersRes,
+  IGetMySubordinatesRes,
+} from '@/types/manager'
 
-type ItemType = GetGroupInvitationRes[] | IGetManagerInvitationRes
+type ItemType =
+  | GetGroupInvitationRes[]
+  | IGetManagerInvitationRes
+  | IGetMySubordinatesRes
+  | IGetMyManagersRes
 
 type ComponentProps<T extends ItemType> = {
   item: T[number]
-  onClickReject: (id: number) => void
+  onClickReject?: (id: number) => void
   onClickAccept?: (id: number) => void
 }
 
@@ -13,8 +21,9 @@ type Props<T extends ItemType> = {
   items: T | undefined
   Component: React.ComponentType<ComponentProps<T>>
   message?: string
-  onClickReject: (id: number) => void
+  onClickReject?: (id: number) => void
   onClickAccept?: (id: number) => void
+  onClickDelete?: (uuid: string) => void
 }
 
 const InvitationLayout = <T extends ItemType>({
@@ -23,6 +32,7 @@ const InvitationLayout = <T extends ItemType>({
   message = '초대가 없습니다',
   onClickReject,
   onClickAccept,
+  onClickDelete,
 }: Props<T>) => {
   return (
     <>
@@ -30,8 +40,9 @@ const InvitationLayout = <T extends ItemType>({
         <Component
           key={idx}
           item={item}
-          onClickReject={onClickReject}
+          {...(onClickReject && { onClickReject })}
           {...(onClickAccept && { onClickAccept })}
+          {...(onClickDelete && { onClickDelete })}
         />
       ))}
       {!items?.length && (

--- a/src/components/setting/ManagerItem.tsx
+++ b/src/components/setting/ManagerItem.tsx
@@ -1,0 +1,24 @@
+import { IManagerUser } from '@/types/manager'
+
+type Props = {
+  item: IManagerUser
+  onClickDelete?: (id: string) => void
+}
+
+const ManagerItem = ({ item, onClickDelete }: Props) => {
+  return (
+    <div className="mb-1 flex items-center justify-between rounded bg-neutral-200 px-3 py-[7px]">
+      <div className="font-bold">{item.name}</div>
+      <div className="flex gap-1">
+        <button
+          className="rounded border bg-red-200 px-2 py-1 text-sm text-red-500"
+          onClick={() => onClickDelete && onClickDelete(item.userUuid)}
+        >
+          초대 거절
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ManagerItem

--- a/src/components/setting/ManagerItem.tsx
+++ b/src/components/setting/ManagerItem.tsx
@@ -14,7 +14,7 @@ const ManagerItem = ({ item, onClickDelete }: Props) => {
           className="rounded border bg-red-200 px-2 py-1 text-sm text-red-500"
           onClick={() => onClickDelete && onClickDelete(item.userUuid)}
         >
-          초대 거절
+          제거
         </button>
       </div>
     </div>

--- a/src/components/setting/ReceivedInvitation.tsx
+++ b/src/components/setting/ReceivedInvitation.tsx
@@ -3,7 +3,7 @@ import { GetGroupInvitationRes } from '@/types/group'
 
 type Props = {
   item: IManagerInvitation | GetGroupInvitationRes
-  onClickReject: (id: number) => void
+  onClickReject?: (id: number) => void
   onClickAccept?: (id: number) => void
 }
 
@@ -38,7 +38,7 @@ const ReceivedInvitation = ({ item, onClickReject, onClickAccept }: Props) => {
             )}
             <button
               className="rounded border bg-red-200 px-2 py-1 text-sm text-red-500"
-              onClick={() => onClickReject(inviteId)}
+              onClick={() => onClickReject && onClickReject(inviteId)}
             >
               초대 거절
             </button>

--- a/src/components/setting/ReceivedInvitation.tsx
+++ b/src/components/setting/ReceivedInvitation.tsx
@@ -59,6 +59,11 @@ const ReceivedInvitation = ({ item, onClickReject, onClickAccept }: Props) => {
             취소된 요청
           </div>
         )}
+        {item.status === 'REMOVED' && (
+          <div className="rounded border border-neutral-500 px-2 py-1 text-sm text-neutral-500">
+            제거된 요청
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/setting/SendedInvitation.tsx
+++ b/src/components/setting/SendedInvitation.tsx
@@ -3,7 +3,7 @@ import { GetGroupInvitationRes } from '@/types/group'
 
 type Props = {
   item: IManagerInvitation | GetGroupInvitationRes
-  onClickReject: (id: number) => void
+  onClickReject?: (id: number) => void
 }
 
 const SendedInvitation = ({ item, onClickReject }: Props) => {
@@ -31,7 +31,7 @@ const SendedInvitation = ({ item, onClickReject }: Props) => {
               요청중
             </div>
             <button
-              onClick={() => onClickReject(inviteId)}
+              onClick={() => onClickReject && onClickReject(inviteId)}
               className="rounded bg-red-200 px-2 py-1 text-sm text-red-500"
             >
               요청 철회

--- a/src/components/setting/SendedInvitation.tsx
+++ b/src/components/setting/SendedInvitation.tsx
@@ -53,6 +53,11 @@ const SendedInvitation = ({ item, onClickReject }: Props) => {
             취소된 요청
           </div>
         )}
+        {item.status === 'REMOVED' && (
+          <div className="rounded border border-neutral-500 px-2 py-1 text-sm text-neutral-500">
+            제거된 요청
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/setting/SettingTitle.tsx
+++ b/src/components/setting/SettingTitle.tsx
@@ -2,12 +2,16 @@ import Divider from '../common/Divider'
 
 type Props = {
   title: string
+  button?: React.ReactElement
 }
 
-const SettingTitle = ({ title }: Props) => {
+const SettingTitle = ({ title, button }: Props) => {
   return (
     <>
-      <h1 className="pb-3 text-xl font-medium">{title}</h1>
+      <div className="flex">
+        <h1 className="pb-3 text-xl font-medium">{title}</h1>
+        {button}
+      </div>
       <Divider />
     </>
   )

--- a/src/components/setting/SettingTitle.tsx
+++ b/src/components/setting/SettingTitle.tsx
@@ -10,7 +10,7 @@ const SettingTitle = ({ title, button }: Props) => {
     <>
       <div className="flex">
         <h1 className="pb-3 text-xl font-medium">{title}</h1>
-        {button}
+        {button && button}
       </div>
       <Divider />
     </>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -48,5 +48,7 @@ export const QUERY_KEYS = {
   PUT_ROUTINE: 'putRoutine',
   GET_MANAGER_INVITATION_SEND: 'managerInvitationSend',
   GET_MANAGER_INVITATION_RECEIVED: 'managerInvitationReceived',
+  GET_MANAGER_MANAGERS: 'myManagers',
+  GET_MANAGER_SUBORDINATES: 'mySubordinates',
   GET_INVITATIONS_USER: 'invitationsUser',
 }

--- a/src/hooks/use-calendar.tsx
+++ b/src/hooks/use-calendar.tsx
@@ -60,7 +60,7 @@ export const useCalendar = ({
           >
             <button
               onClick={() => setCurrentDate(currentDay)}
-              className={`z-50 flex h-9 w-9 items-center justify-center text-base hover:font-bold sm:h-10 sm:w-10 sm:text-lg ${!isCurrentMonth && 'text-neutral-400'} ${scheduleClass} `}
+              className={`z-20 flex h-9 w-9 items-center justify-center text-base hover:font-bold sm:h-10 sm:w-10 sm:text-lg ${!isCurrentMonth && 'text-neutral-400'} ${scheduleClass} `}
             >
               {format(day, dateFormat)}
             </button>

--- a/src/hooks/use-manager.ts
+++ b/src/hooks/use-manager.ts
@@ -1,0 +1,24 @@
+import { getMySubordinates } from '@/api/manager/get-my-subordinates'
+import { QUERY_KEYS } from '@/constants/api'
+import useManagerStore from '@/store/manager'
+import { IGetMySubordinatesRes } from '@/types/manager'
+import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
+
+export const useManager = () => {
+  const { mySubordinates, hasSubordinates, setMySubordinates } =
+    useManagerStore()
+
+  const { data: MySubordinates } = useQuery<IGetMySubordinatesRes>({
+    queryKey: [QUERY_KEYS.GET_MANAGER_SUBORDINATES],
+    queryFn: () => getMySubordinates(),
+  })
+
+  useEffect(() => {
+    if (MySubordinates) {
+      setMySubordinates(MySubordinates)
+    }
+  }, [MySubordinates, setMySubordinates])
+
+  return { mySubordinates, hasSubordinates }
+}

--- a/src/hooks/use-range-schedule.ts
+++ b/src/hooks/use-range-schedule.ts
@@ -5,12 +5,16 @@ import { useQuery } from '@tanstack/react-query'
 import { useUser } from './use-user'
 import { calendarScheduleFilter } from '@/utils/calendar-schedule-filter'
 
-export const useRangeSchedule = (start: string, end: string) => {
+export const useRangeSchedule = (
+  start: string,
+  end: string,
+  userUuid?: string
+) => {
   const { user, isUserLoading } = useUser()
 
   const { isLoading, data } = useQuery<GetSchedulesRes>({
-    queryKey: [QUERY_KEYS.GET_SCHEDULE_BY_RANGE, start],
-    queryFn: () => getScheduleByRange(start, end),
+    queryKey: [QUERY_KEYS.GET_SCHEDULE_BY_RANGE, start, userUuid],
+    queryFn: () => getScheduleByRange(start, end, userUuid),
     enabled: !isUserLoading && !!user.info?.userUuid,
   })
 

--- a/src/pages/create-schedule/CreateManualSchedulePage.tsx
+++ b/src/pages/create-schedule/CreateManualSchedulePage.tsx
@@ -40,8 +40,6 @@ const CreateManualSchedulePage = () => {
       ...data,
     } as PostSchedulesReq
 
-    console.log(payload)
-
     mutation.mutate(payload, {
       onSuccess: (response) => {
         console.log('일정 생성 성공:', response)

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -98,6 +98,9 @@ const SettingManagerPage = () => {
         queryClient.invalidateQueries({
           queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
         })
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEYS.GET_MANAGER_MANAGERS],
+        })
       },
     }
   )

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -8,7 +8,6 @@ import { patchManagerAccept } from '@/api/manager/patch-manager-accept'
 import { patchManagerCancel } from '@/api/manager/patch-manager-cancel'
 import { patchManagerReject } from '@/api/manager/patch-manager-reject'
 import { postManagerInvitation } from '@/api/manager/post-manager-invitation'
-import { Button } from '@/components/common'
 import Toast from '@/components/common/Toast'
 import UserSelector from '@/components/common/UserSelector'
 import RefreshIcon from '@/components/icons/RefreshIcon'
@@ -22,7 +21,6 @@ import SettingSection from '@/components/setting/SettingSection'
 import SettingTitle from '@/components/setting/SettingTitle'
 import { QUERY_KEYS } from '@/constants/api'
 import { useModal } from '@/hooks/use-modal'
-import { path } from '@/routes/path'
 import { UserWithPhoneNumber } from '@/types/auth'
 import {
   IGetManagerInvitationRes,
@@ -35,12 +33,10 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 const SettingManagerPage = () => {
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
   const { isModalOpen, openModal, closeModal } = useModal()
   const [selectedUser, setSelectedUser] = useState<UserWithPhoneNumber | null>(
     null
@@ -208,19 +204,15 @@ const SettingManagerPage = () => {
 
   return (
     <div className="px-5">
-      <Button
-        text="이전으로"
-        onClick={() => {
-          navigate(path.settings.base)
-        }}
-        className="mb-3"
-      />
+      <button className="mb-3 rounded bg-primary-base px-3 py-2 text-sm text-white">
+        이전으로
+      </button>
       <SettingTitle
         title="관리자 관리"
         button={
-          <button onClick={handleAllRefresh}>
+          <div onClick={handleAllRefresh}>
             <RefreshIcon className="mb-2 ml-3" />
-          </button>
+          </div>
         }
       />
 

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -42,14 +42,13 @@ const SettingManagerPage = () => {
   const { data: sendedInvitations } = useQuery<IGetManagerInvitationRes>({
     queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
     queryFn: () => getManagerInvitationSend(),
-    enabled: !selectedUser,
+    // enabled: !selectedUser,
   })
 
   // 받은 초대 현황
   const { data: receivedInvitations } = useQuery<IGetManagerInvitationRes>({
     queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
     queryFn: () => getManagerInvitationReceived(),
-    enabled: !selectedUser,
   })
 
   // 받은 요청 거절
@@ -106,15 +105,13 @@ const SettingManagerPage = () => {
   }
 
   // 새로운 관리자 초대 생성
-  // TODO: 현재 invalidateQueries 사용하여도 '보낸 초대 현황' 다시 요청되지 않음
   const mutation = useMutation<IPostManagerInvitationRes, AxiosError, string>({
     mutationFn: postManagerInvitation,
     onSuccess: () => {
-      closeModal()
+      toast.success('초대에 성공했습니다!')
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
       })
-      toast.success('초대에 성공했습니다!')
     },
     onError: () => {
       closeModal()
@@ -127,9 +124,13 @@ const SettingManagerPage = () => {
     openModal()
   }
 
-  const handleInviteManager = () => {
+  const handleInviteManager = async () => {
     if (selectedUser?.userUuid) {
-      mutation.mutate(selectedUser?.userUuid)
+      try {
+        await mutation.mutateAsync(selectedUser.userUuid)
+      } finally {
+        closeModal()
+      }
     }
   }
 

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -1,5 +1,7 @@
 import { getManagerInvitationReceived } from '@/api/manager/get-manager-invitation-received'
 import { getManagerInvitationSend } from '@/api/manager/get-manager-invitation-send'
+import { getMyManagers } from '@/api/manager/get-my-managers'
+import { getMySubordinates } from '@/api/manager/get-my-subordinates'
 import { patchManagerAccept } from '@/api/manager/patch-manager-accept'
 import { patchManagerCancel } from '@/api/manager/patch-manager-cancel'
 import { patchManagerReject } from '@/api/manager/patch-manager-reject'
@@ -10,6 +12,7 @@ import UserSelector from '@/components/common/UserSelector'
 import InvitationLayout from '@/components/setting/InvitationLayout'
 import InvitationsSection from '@/components/setting/InvitationsSection'
 import InviteModal from '@/components/setting/InviteModal'
+import ManagerItem from '@/components/setting/ManagerItem'
 import ReceivedInvitation from '@/components/setting/ReceivedInvitation'
 import SendedInvitation from '@/components/setting/SendedInvitation'
 import SettingSection from '@/components/setting/SettingSection'
@@ -20,6 +23,8 @@ import { path } from '@/routes/path'
 import { UserWithPhoneNumber } from '@/types/auth'
 import {
   IGetManagerInvitationRes,
+  IGetMyManagersRes,
+  IGetMySubordinatesRes,
   IPatchManagerInvitationRes,
   IPostManagerInvitationRes,
   IRejectManagerInvitationRes,
@@ -49,6 +54,18 @@ const SettingManagerPage = () => {
   const { data: receivedInvitations } = useQuery<IGetManagerInvitationRes>({
     queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
     queryFn: () => getManagerInvitationReceived(),
+  })
+
+  // 자신의 피관리자 목록 조회
+  const { data: MySubordinates } = useQuery<IGetMySubordinatesRes>({
+    queryKey: [QUERY_KEYS.GET_MANAGER_SUBORDINATES],
+    queryFn: () => getMySubordinates(),
+  })
+
+  // 자신의 관리자 목록 조회
+  const { data: MyManagers } = useQuery<IGetMyManagersRes>({
+    queryKey: [QUERY_KEYS.GET_MANAGER_MANAGERS],
+    queryFn: () => getMyManagers(),
   })
 
   // 받은 요청 거절
@@ -134,6 +151,10 @@ const SettingManagerPage = () => {
     }
   }
 
+  // 피관리자 제거
+
+  // 관리자 제거
+
   return (
     <div className="px-5">
       <Button
@@ -193,6 +214,33 @@ const SettingManagerPage = () => {
           onClick={handleInviteManager}
         />
       )}
+
+      <SettingSection title="💌 관리자 목록">
+        <div className="py-3">
+          <InvitationsSection
+            title="내가 관리하는 사람들"
+            itemsLength={MySubordinates?.length || 0}
+          >
+            <InvitationLayout
+              items={MySubordinates}
+              Component={ManagerItem}
+              message="관리하는 사용자가 없습니다"
+              // 피관리자 제거
+            />
+          </InvitationsSection>
+          <InvitationsSection
+            title="나의 관리자들"
+            itemsLength={MyManagers?.length || 0}
+          >
+            <InvitationLayout
+              items={MyManagers}
+              Component={ManagerItem}
+              message="관리자가 없습니다"
+              // 관리자 제거
+            />
+          </InvitationsSection>
+        </div>
+      </SettingSection>
       <Toast />
     </div>
   )

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -1,3 +1,5 @@
+import { deleteManager } from '@/api/manager/delete-manager'
+import { deleteSubordinate } from '@/api/manager/delete-subordinate'
 import { getManagerInvitationReceived } from '@/api/manager/get-manager-invitation-received'
 import { getManagerInvitationSend } from '@/api/manager/get-manager-invitation-send'
 import { getMyManagers } from '@/api/manager/get-my-managers'
@@ -151,10 +153,6 @@ const SettingManagerPage = () => {
     }
   }
 
-  // 피관리자 제거
-
-  // 관리자 제거
-
   return (
     <div className="px-5">
       <Button
@@ -226,20 +224,22 @@ const SettingManagerPage = () => {
               Component={ManagerItem}
               message="관리하는 사용자가 없습니다"
               // 피관리자 제거
-            />
-          </InvitationsSection>
-          <InvitationsSection
-            title="나의 관리자들"
-            itemsLength={MyManagers?.length || 0}
-          >
-            <InvitationLayout
-              items={MyManagers}
-              Component={ManagerItem}
-              message="관리자가 없습니다"
-              // 관리자 제거
+              onClickDelete={deleteSubordinate}
             />
           </InvitationsSection>
         </div>
+        <InvitationsSection
+          title="나의 관리자들"
+          itemsLength={MyManagers?.length || 0}
+        >
+          <InvitationLayout
+            items={MyManagers}
+            Component={ManagerItem}
+            message="관리자가 없습니다"
+            // 관리자 제거
+            onClickDelete={deleteManager}
+          />
+        </InvitationsSection>
       </SettingSection>
       <Toast />
     </div>

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -11,6 +11,7 @@ import { postManagerInvitation } from '@/api/manager/post-manager-invitation'
 import { Button } from '@/components/common'
 import Toast from '@/components/common/Toast'
 import UserSelector from '@/components/common/UserSelector'
+import RefreshIcon from '@/components/icons/RefreshIcon'
 import InvitationLayout from '@/components/setting/InvitationLayout'
 import InvitationsSection from '@/components/setting/InvitationsSection'
 import InviteModal from '@/components/setting/InviteModal'
@@ -156,6 +157,55 @@ const SettingManagerPage = () => {
     }
   }
 
+  // 피관리자 제거
+  const mutateDeleteSubordinate = useMutation<void, AxiosError, string>({
+    mutationFn: (subordinateId: string) => deleteSubordinate(subordinateId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MANAGER_SUBORDINATES],
+      })
+    },
+  })
+
+  const handleDeleteSubordinate = (uuid: string) => {
+    mutateDeleteSubordinate.mutate(uuid)
+  }
+
+  // 관리자 제거
+  const mutateDeleteManager = useMutation<void, AxiosError, string>({
+    mutationFn: (subordinateId: string) => deleteManager(subordinateId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.GET_MANAGER_MANAGERS],
+      })
+    },
+  })
+
+  const handleDeleteManager = (uuid: string) => {
+    mutateDeleteManager.mutate(uuid)
+  }
+
+  const handleAllRefresh = () => {
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_SEND],
+    })
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEYS.GET_MANAGER_INVITATION_RECEIVED],
+    })
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEYS.GET_MANAGER_SUBORDINATES],
+    })
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEYS.GET_MANAGER_MANAGERS],
+    })
+  }
+
   return (
     <div className="px-5">
       <Button
@@ -165,7 +215,14 @@ const SettingManagerPage = () => {
         }}
         className="mb-3"
       />
-      <SettingTitle title="관리자 관리" />
+      <SettingTitle
+        title="관리자 관리"
+        button={
+          <button onClick={handleAllRefresh}>
+            <RefreshIcon className="mb-2 ml-3" />
+          </button>
+        }
+      />
 
       <SettingSection title="💌 관리자 초대하기">
         <div className="mt-3">
@@ -227,7 +284,7 @@ const SettingManagerPage = () => {
               Component={ManagerItem}
               message="관리하는 사용자가 없습니다"
               // 피관리자 제거
-              onClickDelete={deleteSubordinate}
+              onClickDelete={handleDeleteSubordinate}
             />
           </InvitationsSection>
         </div>
@@ -240,7 +297,7 @@ const SettingManagerPage = () => {
             Component={ManagerItem}
             message="관리자가 없습니다"
             // 관리자 제거
-            onClickDelete={deleteManager}
+            onClickDelete={handleDeleteManager}
           />
         </InvitationsSection>
       </SettingSection>

--- a/src/store/manager.ts
+++ b/src/store/manager.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand'
+import { IGetMySubordinatesRes, IManagerUser } from '@/types/manager'
+
+type ManagerState = {
+  mySubordinates: IGetMySubordinatesRes
+  hasSubordinates: boolean
+  selectedSubordinate: IManagerUser | null
+  setMySubordinates: (data: IGetMySubordinatesRes) => void
+  setSelectedSubordinate: (data: IManagerUser | null) => void
+}
+
+const useManagerStore = create<ManagerState>((set) => ({
+  mySubordinates: [],
+  hasSubordinates: false,
+  selectedSubordinate: null,
+  setMySubordinates: (data) =>
+    set(() => ({
+      mySubordinates: data,
+      hasSubordinates: data.length > 0,
+    })),
+  setSelectedSubordinate: (data) =>
+    set(() => ({
+      selectedSubordinate: data,
+    })),
+}))
+
+export default useManagerStore

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -20,3 +20,15 @@ export interface IGetManagerInvitationRes extends Array<IManagerInvitation> {}
 export interface IRejectManagerInvitationRes extends IManagerInvitation {}
 
 export interface IPatchManagerInvitationRes extends IManagerInvitation {}
+
+export interface IManagerUser {
+  userUuid: string
+  name: string
+  profileImage: string
+  email: string
+  isManager: boolean
+}
+
+export interface IGetMyManagersRes extends Array<IManagerUser> {}
+
+export interface IGetMySubordinatesRes extends Array<IManagerUser> {}


### PR DESCRIPTION
## ✅ 이슈 번호
#66 

## ✅ 작업 내용
- 관리자 페이지에 API 호출 이후 react-query의 `invalidateQueries`를 통해 최신 데이터를 반영하여 UI 반응성 개선
- 관리자, 피관리자 목록 조회 및 제거 로직 연결
- 관리자 사용자인지 `피관리자 목록 api 콜 response 길이 >= 1`를 통해 판별 -> 전역 상태로 정보 저장 -> 관리자 사용자일경우 Header에 관리자 Icon 나타남 -> 관리자 Icon을 통해 관리자 사이드바로 접근 가능
- 사이드바 피관리자 목록 출력 -> 특정 피관리자 선택시(Radio), 해당 피관리자의 일정 조회 가능 
  - 한번에 한명의 피관리자 일정만 조회 가능
- 피관리자 일정 조회 해제하는 초기화 버튼 사이드바 내부에 생성

<img src="https://github.com/user-attachments/assets/954fb195-bb66-44cf-bbd5-ef98250b2e28" width="300px" />

## ✅ 공유 사항
- 재우님께서 name과 임의의 phoneNumber를 통해 accessToken을 발급할 수 있는 임시 api를 만들어주셨습니다. 오늘 sms 일일 사용량이 초과했다고 하니, 로컬 수정사항 반영을 위해 해당 api를 써야 할 것 같습니다.
- 캡쳐 사이드메뉴 하단 ui는 앞서 언급한 긴급 accessToken 발급 위해 마련한 것으로 main merge 버전에는 포함되어 있지 않습니다.