### PR TITLE
[FIX] form label issue 제거 및 관리자 관리 용어 수정

### DIFF
--- a/src/components/common/UserSelector.tsx
+++ b/src/components/common/UserSelector.tsx
@@ -47,6 +47,7 @@ const UserSelector = ({ onClick }: Props) => {
     <div className="mx-auto">
       <div className="relative">
         <input
+          id="text"
           type="text"
           placeholder="이름, 전화번호, 이메일을 입력해주세요"
           className="w-full rounded-md border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/src/components/common/schedule-form/field-components/BaseField.tsx
+++ b/src/components/common/schedule-form/field-components/BaseField.tsx
@@ -22,12 +22,12 @@ const BaseField = ({
   return (
     <div className="mb-6">
       <div className="flex items-center justify-between">
-        <label
-          htmlFor={id}
+        <div
+          id={id}
           className="mb-2 block text-base font-bold text-neutral-700"
         >
           {label}
-        </label>
+        </div>
         {hasLength && (
           <p className="text-xs text-neutral-500">
             {length} / {TEXT_MAX_LENGTH}

--- a/src/components/common/schedule-form/field-components/CategoryField.tsx
+++ b/src/components/common/schedule-form/field-components/CategoryField.tsx
@@ -21,12 +21,12 @@ const CategoryField = () => {
 
   return (
     <div className="mb-4 flex justify-between">
-      <label
-        htmlFor="categoryId"
+      <div
+        id="categoryId"
         className="w-36 py-5 text-base font-bold text-neutral-700"
       >
         카테고리
-      </label>
+      </div>
 
       <div>
         <Controller
@@ -39,6 +39,7 @@ const CategoryField = () => {
           }) => (
             <div className="flex-grow py-4">
               <Select
+                id="categoryId"
                 {...rest}
                 ref={ref}
                 aria-label="카테고리 선택"

--- a/src/components/common/schedule-form/field-components/DateTimeField.tsx
+++ b/src/components/common/schedule-form/field-components/DateTimeField.tsx
@@ -103,10 +103,10 @@ const DateTimeField = () => {
 
             <div className="space-y-4">
               <div className="flex justify-between">
-                <label className="mb-1 block w-7 py-3 text-sm text-xs font-medium text-neutral-700 sm:w-20 sm:text-base">
+                <div className="mb-1 block w-7 py-3 text-sm text-xs font-medium text-neutral-700 sm:w-20 sm:text-base">
                   <span>시작</span>
                   <span className="hidden sm:inline"> 일자</span>
-                </label>
+                </div>
                 <Controller
                   name="startDate"
                   control={control}
@@ -147,10 +147,10 @@ const DateTimeField = () => {
               </div>
 
               <div className="flex justify-between">
-                <label className="mb-1 block w-7 py-3 text-xs font-medium text-neutral-700 sm:w-20 sm:text-base">
+                <div className="mb-1 block w-7 py-3 text-xs font-medium text-neutral-700 sm:w-20 sm:text-base">
                   <span>종료</span>
                   <span className="hidden sm:inline"> 일자</span>
-                </label>
+                </div>
                 <Controller
                   name="endDate"
                   control={control}

--- a/src/components/common/schedule-form/field-components/RepetitionField.tsx
+++ b/src/components/common/schedule-form/field-components/RepetitionField.tsx
@@ -56,7 +56,9 @@ const RepetitionField = () => {
 
   return (
     <>
-      <div className="hidden">{isRecurring}</div>
+      <div id="isRecurring" className="hidden">
+        {isRecurring}
+      </div>
       {/* <div className="hidden">{settedRepeatType}</div>
       <BaseField
         id="repitition"

--- a/src/components/setting/InvitationsSection.tsx
+++ b/src/components/setting/InvitationsSection.tsx
@@ -2,11 +2,17 @@ import { ReactNode } from 'react'
 
 type Props = {
   title: string
+  description?: string
   children?: ReactNode
   itemsLength?: number
 }
 
-const InvitationsSection = ({ title, children, itemsLength = -1 }: Props) => {
+const InvitationsSection = ({
+  title,
+  children,
+  description,
+  itemsLength = -1,
+}: Props) => {
   return (
     <>
       <div className="flex gap-2">
@@ -15,6 +21,9 @@ const InvitationsSection = ({ title, children, itemsLength = -1 }: Props) => {
           <div className="text-[16px] text-neutral-500">총 {itemsLength}건</div>
         )}
       </div>
+      {description && (
+        <div className="py-1 text-[14px] sm:text-[16px]">{description}</div>
+      )}
       <div className="min-h-12 py-2">{children}</div>
     </>
   )

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -221,23 +221,24 @@ const SettingManagerPage = () => {
       <SettingTitle
         title="관리자 관리"
         button={
-          <div onClick={handleAllRefresh}>
+          <div className="pt-2" onClick={handleAllRefresh}>
             <RefreshIcon className="mb-2 ml-3" />
           </div>
         }
       />
 
-      <SettingSection title="💌 관리자 초대하기">
+      <SettingSection title="💌 피관리자에게 초대보내기">
         <div className="mt-3">
           <UserSelector onClick={handleInviteManagerModal} />
         </div>
       </SettingSection>
 
-      <SettingSection title="💌 초대 목록">
+      <SettingSection title="💌 초대 현황">
         <div className="py-3">
           <InvitationsSection
             title="받은 초대 현황"
             itemsLength={receivedInvitations?.length || 0}
+            description="💡 받은 초대를 수락하면 피관리자로 등록됩니다"
           >
             <InvitationLayout
               items={receivedInvitations}
@@ -254,6 +255,7 @@ const SettingManagerPage = () => {
           <InvitationsSection
             title="보낸 초대 현황"
             itemsLength={sendedInvitations?.length || 0}
+            description="💡 보낸 초대가 수락되면 관리자로 등록됩니다"
           >
             <InvitationLayout
               items={sendedInvitations}

--- a/src/pages/setting/SettingManagerPage.tsx
+++ b/src/pages/setting/SettingManagerPage.tsx
@@ -8,6 +8,7 @@ import { patchManagerAccept } from '@/api/manager/patch-manager-accept'
 import { patchManagerCancel } from '@/api/manager/patch-manager-cancel'
 import { patchManagerReject } from '@/api/manager/patch-manager-reject'
 import { postManagerInvitation } from '@/api/manager/post-manager-invitation'
+import { Button } from '@/components/common'
 import Toast from '@/components/common/Toast'
 import UserSelector from '@/components/common/UserSelector'
 import RefreshIcon from '@/components/icons/RefreshIcon'
@@ -21,6 +22,7 @@ import SettingSection from '@/components/setting/SettingSection'
 import SettingTitle from '@/components/setting/SettingTitle'
 import { QUERY_KEYS } from '@/constants/api'
 import { useModal } from '@/hooks/use-modal'
+import { path } from '@/routes/path'
 import { UserWithPhoneNumber } from '@/types/auth'
 import {
   IGetManagerInvitationRes,
@@ -33,10 +35,12 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 const SettingManagerPage = () => {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
   const { isModalOpen, openModal, closeModal } = useModal()
   const [selectedUser, setSelectedUser] = useState<UserWithPhoneNumber | null>(
     null
@@ -215,9 +219,11 @@ const SettingManagerPage = () => {
 
   return (
     <div className="px-5">
-      <button className="mb-3 rounded bg-primary-base px-3 py-2 text-sm text-white">
-        이전으로
-      </button>
+      <Button
+        className="mb-3"
+        text="이전으로"
+        onClick={() => navigate(path.settings.base)}
+      />
       <SettingTitle
         title="관리자 관리"
         button={


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
- 일정 폼 하단 issue 탭에서 발생하고 있던 label 관련 이슈를 제거했습니다
<img width="300px" alt="Screenshot 2024-10-17 at 1 44 09 PM" src="https://github.com/user-attachments/assets/8a426f79-add0-465f-9abf-01e74762b746">
</br>

- 관리자 설정 페이지에서 사용되던 `관리자 초대` 등의 용어에 모호함이 있다는 다희님의 피드백에 따라 용어를 수정했습니다
  - `피관리자` 단어 사용해 모호함 줄임
  - 보낸 초대와 받은 초대에 설명 추가
<img width="207" alt="Screenshot 2024-10-17 at 1 47 40 PM" src="https://github.com/user-attachments/assets/2ab981b6-81b0-47ce-b720-8510058ae29f">

## ✅ 공유 사항
