### PR TITLE
[FIX] 잘못 연결된 subordinateName -> managerName 으로 수정

### DIFF
--- a/src/components/setting/ReceivedInvitation.tsx
+++ b/src/components/setting/ReceivedInvitation.tsx
@@ -42,7 +42,7 @@ const ReceivedInvitation = ({ item, onClickReject, onClickAccept }: Props) => {
         <div className="font-bold">{item.groupName}</div>
       )}
       <div className="font-bold">
-        {isManagerInvitation(item) ? item.subordinateName : item.inviterName}
+        {isManagerInvitation(item) ? item.managerName : item.inviterName}
       </div>
       <div className="flex gap-1">
         {item.status === 'PENDING' && (


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
- 관리자 초대 요청 data 출력 시, 잘못 출력되던 subordinateName -> managerName 으로 수정

## ✅ 공유 사항
