### PR TITLE
[FIX] mySubordinates  오류 해결

### DIFF
--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -15,6 +15,8 @@ const SideBar = ({ isSidebarOpen, toggleSidebar }: Props) => {
     setSelectedSubordinate(null)
   }
 
+  if (!Array.isArray(mySubordinates) || mySubordinates.length === 0) return null
+
   return (
     <>
       {isSidebarOpen && (


### PR DESCRIPTION
## ✅ 이슈 번호

## ✅ 작업 내용
useManager hook의 mySubordinates에 요청 결과 배열이 아닌 값이 저장될 경우 SideBar 컴포넌트에서 오류가 발생했습니다.
이를 방지하기 위해, mySubordinates가 배열이 맞는 경우에만 SideBar를 표시하도록 로직 수정하였습니다.

## ✅ 공유 사항
